### PR TITLE
[#6] title added to the editor

### DIFF
--- a/apps/platform/app/(platform)/repositories/[repository]/architecture/components/EditorPanel/extensions.ts
+++ b/apps/platform/app/(platform)/repositories/[repository]/architecture/components/EditorPanel/extensions.ts
@@ -21,6 +21,7 @@ import {
   UpdatedImage,
   UploadImagesPlugin,
   Youtube,
+  FirstHeading,
 } from "@thinkthroo/editor";
 
 import { cx } from "class-variance-authority";
@@ -155,6 +156,8 @@ const markdownExtension = MarkdownExtension.configure({
   transformCopiedText: false,
 });
 
+const firstHeading = FirstHeading.configure();
+
 export const defaultExtensions = [
   starterKit,
   placeholder,
@@ -177,4 +180,5 @@ export const defaultExtensions = [
   Color,
   CustomKeymap,
   GlobalDragHandle,
+  firstHeading,
 ];

--- a/apps/platform/app/(platform)/repositories/[repository]/architecture/components/EditorPanel/index.tsx
+++ b/apps/platform/app/(platform)/repositories/[repository]/architecture/components/EditorPanel/index.tsx
@@ -29,6 +29,7 @@ import GenerativeMenuSwitch from "./generative/generative-menu-switch";
 import { uploadFn } from "./image-upload";
 import { TextButtons } from "./selectors/text-buttons";
 import { slashCommand, suggestionItems } from "./slash-command";
+
 import hljs from "highlight.js";
 
 const extensions = [...defaultExtensions, slashCommand];
@@ -59,13 +60,17 @@ export default function EditorPanel({ documentId }: EditorPanelProps) {
       type: "doc",
       content: [
         {
-          type: "paragraph",
+          type: "heading",
+          attrs: { level: 1 },
           content: [
             {
               type: "text",
-              text: "Start writing your document here...",
+              text: "Untitled Document",
             },
           ],
+        },
+        {
+          type: "paragraph",
         },
       ],
     }),

--- a/packages/editor/src/extensions/first-heading.ts
+++ b/packages/editor/src/extensions/first-heading.ts
@@ -1,0 +1,40 @@
+import { Extension } from '@tiptap/core';
+import { Plugin, PluginKey } from '@tiptap/pm/state';
+
+/**
+ * Extension that ensures the first block in the document is always a heading.
+ * If user tries to change it to something else, it converts it back to a heading.
+ */
+export const FirstHeading = Extension.create({
+  name: 'firstHeading',
+
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        key: new PluginKey('firstHeading'),
+        appendTransaction: (transactions, oldState, newState) => {
+          // Check if document structure changed
+          const docChanged = transactions.some(tr => tr.docChanged);
+          if (!docChanged) return null;
+
+          const { doc } = newState;
+          const firstNode = doc.firstChild;
+
+          // If first node exists and is NOT a heading, convert it
+          if (firstNode && firstNode.type.name !== 'heading') {
+            const tr = newState.tr;
+            
+            // Convert first node to heading level 1
+            tr.setNodeMarkup(0, newState.schema.nodes.heading, {
+              level: 1,
+            });
+
+            return tr;
+          }
+
+          return null;
+        },
+      }),
+    ];
+  },
+});

--- a/packages/editor/src/extensions/index.ts
+++ b/packages/editor/src/extensions/index.ts
@@ -16,6 +16,7 @@ import { ImageResizer } from "./image-resizer";
 import { Twitter } from "./twitter";
 import { Mathematics } from "./mathematics";
 import UpdatedImage from "./updated-image";
+import { FirstHeading } from "./first-heading";
 
 import CharacterCount from "@tiptap/extension-character-count";
 import CodeBlockLowlight from "@tiptap/extension-code-block-lowlight";
@@ -23,8 +24,13 @@ import Youtube from "@tiptap/extension-youtube";
 import GlobalDragHandle from "tiptap-extension-global-drag-handle";
 
 const PlaceholderExtension = Placeholder.configure({
-  placeholder: ({ node }) => {
+  placeholder: ({ node, pos, editor }) => {
     if (node.type.name === "heading") {
+      // Check if this is the first node in the document
+      const firstNode = editor.state.doc.firstChild;
+      if (firstNode && firstNode === node) {
+        return "Title";
+      }
       return `Heading ${node.attrs.level}`;
     }
     return "Press '/' for commands";
@@ -85,4 +91,5 @@ export {
   Mathematics,
   CharacterCount,
   GlobalDragHandle,
+  FirstHeading,
 };

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -46,6 +46,7 @@ export {
   createSuggestionItems,
   handleCommandNavigation,
   type SuggestionItem,
+  FirstHeading,
 } from "./extensions";
 
 // Plugins


### PR DESCRIPTION
## Summary by Sourcery

Enforce a dedicated title heading as the first block in the editor and expose the supporting editor extension.

New Features:
- Initialize new documents with an H1 heading titled "Untitled Document" followed by an empty paragraph.
- Introduce a FirstHeading editor extension that forces the first block in the document to remain a level-1 heading.
- Add a special placeholder label "Title" for the first heading node to distinguish it from other headings.

Enhancements:
- Export the FirstHeading extension from the shared editor package and wire it into the platform editor's default extension set.