### PR TITLE
build fix with tracking

### DIFF
--- a/apps/platform/app/(auth)/login/page.tsx
+++ b/apps/platform/app/(auth)/login/page.tsx
@@ -1,29 +1,11 @@
-"use client";
+import { LoginPageClient } from "@/components/login-page-client";
 
-import { useEffect } from "react";
-import { LoginForm } from "@/components/login-form";
-import { useUmamiTracking } from "@/hooks/useUmamiTracking";
-
-export default function Page({
+export default async function Page({
   searchParams,
 }: {
-  searchParams?: { error?: string };
+  searchParams?: Promise<{ error?: string }>;
 }) {
-  const { trackEvent } = useUmamiTracking();
-
-  useEffect(() => {
-    trackEvent("page_visit", {
-      page: "login",
-      timestamp: new Date().toISOString(),
-    });
-  }, [trackEvent]);
-
-  const error = searchParams?.error;
-  return (
-    <div className="flex min-h-svh w-full items-center justify-center p-6 md:p-10">
-      <div className="w-full max-w-sm">
-        <LoginForm error={error} />
-      </div>
-    </div>
-  );
+  const error = (await searchParams)?.error;
+  
+  return <LoginPageClient error={error} />;
 }

--- a/apps/platform/components/login-page-client.tsx
+++ b/apps/platform/components/login-page-client.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useEffect } from "react";
+import { LoginForm } from "@/components/login-form";
+import { useUmamiTracking } from "@/hooks/useUmamiTracking";
+
+export function LoginPageClient({ error }: { error?: string }) {
+  const { trackEvent } = useUmamiTracking();
+
+  useEffect(() => {
+    trackEvent("page_visit", {
+      page: "login",
+      timestamp: new Date().toISOString(),
+    });
+  }, [trackEvent]);
+
+  return (
+    <div className="flex min-h-svh w-full items-center justify-center p-6 md:p-10">
+      <div className="w-full max-w-sm">
+        <LoginForm error={error} />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary by Sourcery

Split the login page into a server component and a client-side wrapper to restore tracking while supporting async search params.

Bug Fixes:
- Restore Umami page visit tracking on the login page after converting it to support async search params.

Enhancements:
- Extract a reusable client-side LoginPageClient component that renders the login form and handles tracking logic.