### PR TITLE
[#42] Login redirect

### DIFF
--- a/apps/www/components/interfaces/site/header/auth-buttons.tsx
+++ b/apps/www/components/interfaces/site/header/auth-buttons.tsx
@@ -13,8 +13,8 @@ export function AuthButtons() {
         <Link 
           target="_blank" 
           rel="noreferrer" 
-          href="https://app.thinkthroo.com/signin/email_signin"
-          onClick={() => track('navigation-click', { menu_item: 'login', href: 'https://app.thinkthroo.com/signin/email_signin' })}
+          href="https://app.thinkthroo.com/login"
+          onClick={() => track('navigation-click', { menu_item: 'login', href: 'https://app.thinkthroo.com/login' })}
         >
           Login
         </Link>
@@ -23,8 +23,8 @@ export function AuthButtons() {
         <Link 
           target="_blank" 
           rel="noreferrer" 
-          href="https://app.thinkthroo.com/signin/email_signin"
-          onClick={() => track('navigation-click', { menu_item: 'signup', href: 'https://app.thinkthroo.com/signin/email_signin' })}
+          href="https://app.thinkthroo.com/login"
+          onClick={() => track('navigation-click', { menu_item: 'signup', href: 'https://app.thinkthroo.com/login' })}
         >
           Signup
         </Link>


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correct login and signup header buttons to redirect to the new /login endpoint instead of the old email_signin URL.