### PR TITLE
Add promo code card under blog TOC

### DIFF
--- a/apps/www/app/(modules)/blog/[slug]/layout.tsx
+++ b/apps/www/app/(modules)/blog/[slug]/layout.tsx
@@ -1,14 +1,15 @@
-import { DocsLayout } from "fumadocs-ui/layouts/docs";
-import React, { ReactNode } from "react";
-import { getBlogTree } from "@/lib/blog-tree";
+import { DocsLayout } from "fumadocs-ui/layouts/docs"
+import React, { ReactNode } from "react"
+import { getBlogTree } from "@/lib/blog-tree"
+import { BlogTocPromo } from "@/components/interfaces/blog/blogtocpromo"
 
 export default async function Layout({ children }: { children: ReactNode }) {
-  // Fetch cached blog tree - uses React cache() to deduplicate within render
-  const tree = await getBlogTree();
+  const tree = await getBlogTree()
 
   return (
     <DocsLayout tree={tree}>
+      <BlogTocPromo />
       {children}
     </DocsLayout>
-  );
+  )
 }

--- a/apps/www/components/interfaces/blog/blogtocpromo.tsx
+++ b/apps/www/components/interfaces/blog/blogtocpromo.tsx
@@ -1,0 +1,24 @@
+"use client"
+
+import { useEffect } from "react"
+import { createRoot } from "react-dom/client"
+import { PromoCard } from "./promo-card"
+
+export function BlogTocPromo() {
+  useEffect(() => {
+    const toc = document.getElementById("nd-toc")
+    if (!toc) return
+
+    if (toc.querySelector("[data-blog-promo]")) return
+
+    const wrapper = document.createElement("div")
+    wrapper.setAttribute("data-blog-promo", "true")
+    wrapper.className = "mt-4"
+
+    toc.appendChild(wrapper)
+
+    createRoot(wrapper).render(<PromoCard />)
+  }, [])
+
+  return null
+}

--- a/apps/www/components/interfaces/blog/promo-card.tsx
+++ b/apps/www/components/interfaces/blog/promo-card.tsx
@@ -1,0 +1,32 @@
+import { Card, CardContent } from "@thinkthroo/ui/components/card"
+import { Button } from "@thinkthroo/ui/components/button"
+
+export function PromoCard() {
+  return (
+    <Card className="rounded-lg bg-muted/30">
+      <CardContent className="p-6 space-y-4">
+        <h4 className="text-lg font-semibold leading-tight">
+          Get 10% off Think Throo
+        </h4>
+
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          Trusted by OpenAI, Sonos, Adobe and more.  
+          Use this promo code when signing up.
+        </p>
+
+        <div className="flex items-center gap-3 pt-2">
+          <code className="rounded-md bg-muted px-3 py-1.5 text-sm font-mono">
+            THINKBLOG10
+          </code>
+
+          <Button
+            size="sm"
+            onClick={() => navigator.clipboard.writeText("THINKBLOG10")}
+          >
+            Copy
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}


### PR DESCRIPTION
## Summary by Sourcery

Add a promotional card component to blog pages and render it within the blog table of contents sidebar.

New Features:
- Introduce a reusable promo card component displaying a Think Throo discount code with a copy-to-clipboard action.
- Inject the promo card into the blog table of contents area on blog article pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a promotional offer component to blog articles, featuring a discount code that readers can easily copy to their clipboard with a single click.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->