### PR TITLE
pricing modal

### DIFF
--- a/apps/platform/app/(platform)/account/billing/page.tsx
+++ b/apps/platform/app/(platform)/account/billing/page.tsx
@@ -10,11 +10,13 @@ import { Check } from "lucide-react"
 import { DataTable } from "@/components/subscription-table/data-table"
 import { columns } from "@/components/subscription-table/columns"
 import DeleteOrganizationModal from "@/components/delete-organization-modal"
+import ChangeSubscriptionPlanModal from "@/components/change-subscription-plan-modal"
 import posthog from "posthog-js"
 
 export default function BillingPage() {
   const invoices: any[] = []
   const [openDelete, setOpenDelete] = useState(false)
+  const [openPlans, setOpenPlans] = useState(false)
 
   const handleDeleteAccount = () => {
     posthog.capture("delete_account_clicked", {
@@ -68,8 +70,8 @@ export default function BillingPage() {
                 <p className="text-sm text-muted-foreground mt-1">$15 per user/month, billed monthly</p>
               </div>
               <div className="flex items-center gap-3">
-                <Button variant="ghost" className="text-sm font-medium">View all plans</Button>
-                <Button className="bg-black hover:bg-black/80 text-white">Upgrade now</Button>
+                <Button variant="ghost" className="text-sm font-medium" onClick={() => setOpenPlans(true)}>View all plans</Button>
+                <Button className="bg-black hover:bg-black/80 text-white" onClick={() => setOpenPlans(true)}>Upgrade now</Button>
               </div>
             </div>
             <Separator />
@@ -93,6 +95,12 @@ export default function BillingPage() {
       <DeleteOrganizationModal
         open={openDelete}
         onClose={() => setOpenDelete(false)}
+      />
+
+      {/* Change Subscription Plan Modal */}
+      <ChangeSubscriptionPlanModal
+        open={openPlans}
+        onClose={() => setOpenPlans(false)}
       />
     </>
     </PrivatePageGuard>

--- a/apps/platform/app/(platform)/account/page.tsx
+++ b/apps/platform/app/(platform)/account/page.tsx
@@ -13,12 +13,14 @@ import { DataTable as MembersTable } from "@/components/members-table/data-table
 import { columns as memberColumns } from "@/components/members-table/columns"
 import type { Member } from "@/components/members-table/columns"
 import DeleteOrganizationModal from "@/components/delete-organization-modal"
+import ChangeSubscriptionPlanModal from "@/components/change-subscription-plan-modal"
 import { Tabs, TabsList, TabsTrigger } from "@thinkthroo/ui/components/tabs"
 import posthog from "posthog-js"
 
 export default function AccountPage() {
   const [activeTab, setActiveTab] = useState<"billing" | "members">("billing")
   const [openDelete, setOpenDelete] = useState(false)
+  const [openPlans, setOpenPlans] = useState(false)
   const invoices: any[] = []
   const members: Member[] = []
 
@@ -80,8 +82,8 @@ export default function AccountPage() {
                       <p className="text-sm text-muted-foreground mt-1">$15 per user/month, billed monthly</p>
                     </div>
                     <div className="flex items-center gap-3">
-                      <Button variant="ghost" className="text-sm font-medium">View all plans</Button>
-                      <Button className="bg-black hover:bg-black/80 text-white">Upgrade now</Button>
+                      <Button variant="ghost" className="text-sm font-medium" onClick={() => setOpenPlans(true)}>View all plans</Button>
+                      <Button className="bg-black hover:bg-black/80 text-white" onClick={() => setOpenPlans(true)}>Upgrade now</Button>
                     </div>
                   </div>
                   <Separator />
@@ -110,6 +112,11 @@ export default function AccountPage() {
         <DeleteOrganizationModal
           open={openDelete}
           onClose={() => setOpenDelete(false)}
+        />
+
+        <ChangeSubscriptionPlanModal
+          open={openPlans}
+          onClose={() => setOpenPlans(false)}
         />
       </>
     </PrivatePageGuard>

--- a/apps/platform/components/change-subscription-plan-modal.tsx
+++ b/apps/platform/components/change-subscription-plan-modal.tsx
@@ -1,0 +1,241 @@
+"use client"
+
+import { useState } from "react"
+import { Check, ExternalLink, Loader2, X } from "lucide-react"
+import { Button } from "@thinkthroo/ui/components/button"
+import { Badge } from "@thinkthroo/ui/components/badge"
+import { Switch } from "@thinkthroo/ui/components/switch"
+import { cn } from "@/lib/utils"
+import { toast } from "sonner"
+import posthog from "posthog-js"
+
+type Props = {
+  open: boolean
+  onClose: () => void
+}
+
+const openSourceFeatures = [
+  "Pro for open source repos",
+  "Limited security scans for 3 repos",
+  "Security scans done biweekly",
+]
+
+const proFeatures = [
+  "Code review for private repos",
+  "Summaries and diagrams of code changes",
+  "Line by line code reviews",
+  "Limited security scans for 10 repos",
+  "Security scans done biweekly",
+  "Custom review rules",
+]
+
+const teamFeatures = [
+  "Repo analytics",
+  "Security scans for 200+ repos",
+  "See and fix unlimited security issues",
+  "Security scans done daily",
+  "3x code review rate limits",
+  "Bring your own LLM",
+]
+
+const enterpriseFeatures = [
+  "Self-hosting option",
+  "Priority support",
+  "Customer success manager",
+  "Invoice billing",
+]
+
+export default function ChangeSubscriptionPlanModal({ open, onClose }: Props) {
+  const [proBilledYearly, setProBilledYearly] = useState(false)
+  const [teamBilledYearly, setTeamBilledYearly] = useState(false)
+  const [loadingPlan, setLoadingPlan] = useState<string | null>(null)
+
+  if (!open) return null
+
+  async function handleUpgrade(plan: "pro" | "team" | "enterprise") {
+    setLoadingPlan(plan)
+    posthog.capture("upgrade_clicked", {
+      plan,
+      billedYearly: plan === "pro" ? proBilledYearly : plan === "team" ? teamBilledYearly : false,
+      timestamp: new Date().toISOString(),
+    })
+    // Simulate brief loading then notify
+    await new Promise((r) => setTimeout(r, 600))
+    toast.success(
+      plan === "enterprise"
+        ? "We'll be in touch soon!"
+        : `Upgrading to ${plan.charAt(0).toUpperCase() + plan.slice(1)} — checkout coming soon!`
+    )
+    setLoadingPlan(null)
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center p-4">
+      <div className="bg-white dark:bg-background w-full max-w-5xl rounded-xl shadow-xl overflow-y-auto max-h-[90vh]">
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 pt-6 pb-4">
+          <h2 className="text-xl font-semibold">Change subscription plan</h2>
+          <div className="flex items-center gap-4">
+            <a
+              href="https://thinkthroo.com/pricing"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-1 text-sm font-medium text-foreground hover:underline"
+            >
+              Pricing
+              <ExternalLink className="w-3.5 h-3.5" />
+            </a>
+            <button
+              onClick={onClose}
+              className="text-muted-foreground hover:text-foreground transition-colors"
+              aria-label="Close"
+            >
+              <X className="w-5 h-5" />
+            </button>
+          </div>
+        </div>
+
+        {/* Plan cards */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 px-6 pb-6">
+          {/* Open Source */}
+          <div className="rounded-xl border border-border p-5 flex flex-col gap-4">
+            <div>
+              <div className="flex items-center gap-2 mb-2">
+                <span className="font-semibold text-base">Open Source</span>
+                <Badge variant="outline" className="text-xs">Current</Badge>
+              </div>
+              <p className="text-2xl font-bold">
+                $0 <span className="text-sm font-normal text-muted-foreground">per user/month</span>
+              </p>
+            </div>
+
+            <Button
+              variant="outline"
+              disabled
+              className="w-full text-muted-foreground border-muted cursor-not-allowed"
+            >
+              Current plan
+            </Button>
+
+            <ul className="space-y-2 text-sm">
+              {openSourceFeatures.map((f) => (
+                <li key={f} className="flex items-start gap-2">
+                  <Check className="w-4 h-4 text-[#7000FF] mt-0.5 shrink-0" />
+                  <span>{f}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          {/* Pro */}
+          <div className="rounded-xl border-2 border-[#7000FF] p-5 flex flex-col gap-4">
+            <div>
+              <div className="flex items-center gap-2 mb-2">
+                <span className="font-semibold text-base">Pro</span>
+                <Badge variant="outline" className="text-xs text-foreground border-foreground">
+                  Suggested
+                </Badge>
+              </div>
+              <p className="text-2xl font-bold">
+                $15 <span className="text-sm font-normal text-muted-foreground">per user/month</span>
+              </p>
+              <div className="flex items-center gap-2 mt-2">
+                <Switch
+                  checked={proBilledYearly}
+                  onCheckedChange={setProBilledYearly}
+                />
+                <span className="text-sm text-muted-foreground">Billed yearly</span>
+              </div>
+            </div>
+
+            <Button
+              className="w-full bg-[#7000FF] text-white hover:bg-[#7000FF]/90 hover:brightness-110 hover:scale-[1.02] transition-all font-semibold"
+              onClick={() => handleUpgrade("pro")}
+              disabled={loadingPlan !== null}
+            >
+              {loadingPlan === "pro" ? <Loader2 className="w-4 h-4 animate-spin" /> : "Upgrade"}
+            </Button>
+
+            <ul className="space-y-2 text-sm">
+              {proFeatures.map((f) => (
+                <li key={f} className="flex items-start gap-2">
+                  <Check className="w-4 h-4 text-[#7000FF] mt-0.5 shrink-0" />
+                  <span>{f}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          {/* Team */}
+          <div className="rounded-xl border border-border p-5 flex flex-col gap-4">
+            <div>
+              <div className="flex items-center gap-2 mb-2">
+                <span className="font-semibold text-base">Team</span>
+              </div>
+              <p className="text-2xl font-bold">
+                $30 <span className="text-sm font-normal text-muted-foreground">per user/month</span>
+              </p>
+              <div className="flex items-center gap-2 mt-2">
+                <Switch
+                  checked={teamBilledYearly}
+                  onCheckedChange={setTeamBilledYearly}
+                />
+                <span className="text-sm text-muted-foreground">Billed yearly</span>
+              </div>
+            </div>
+
+            <Button
+              className="w-full bg-[#7000FF] text-white hover:bg-[#7000FF]/90 hover:brightness-110 hover:scale-[1.02] transition-all font-semibold"
+              onClick={() => handleUpgrade("team")}
+              disabled={loadingPlan !== null}
+            >
+              {loadingPlan === "team" ? <Loader2 className="w-4 h-4 animate-spin" /> : "Upgrade"}
+            </Button>
+
+            <div className="space-y-2 text-sm">
+              <p className="text-muted-foreground">Everything in Pro, plus:</p>
+              <ul className="space-y-2">
+                {teamFeatures.map((f) => (
+                  <li key={f} className="flex items-start gap-2">
+                    <Check className="w-4 h-4 text-[#7000FF] mt-0.5 shrink-0" />
+                    <span>{f}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+
+          {/* Enterprise */}
+          <div className="rounded-xl border border-border p-5 flex flex-col gap-4">
+            <div>
+              <div className="flex items-center gap-2 mb-2">
+                <span className="font-semibold text-base">Enterprise</span>
+              </div>
+              <p className="text-2xl font-bold">Talk to us</p>
+            </div>
+
+            <Button
+              className="w-full bg-[#7000FF] text-white hover:bg-[#7000FF]/90 hover:brightness-110 hover:scale-[1.02] transition-all font-semibold"
+              onClick={() => handleUpgrade("enterprise")}
+              disabled={loadingPlan !== null}
+            >
+              {loadingPlan === "enterprise" ? <Loader2 className="w-4 h-4 animate-spin" /> : "Contact us"}
+            </Button>
+
+            <div className="space-y-2 text-sm">
+              <p className="text-muted-foreground">Everything in Team, plus:</p>
+              <ul className="space-y-2">
+                {enterpriseFeatures.map((f) => (
+                  <li key={f} className="flex items-start gap-2">
+                    <Check className="w-4 h-4 text-[#7000FF] mt-0.5 shrink-0" />
+                    <span>{f}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary by Sourcery

Add a subscription plan selection modal and wire billing actions to open it from account pages.

New Features:
- Introduce a ChangeSubscriptionPlanModal component that presents Open Source, Pro, Team, and Enterprise plans with feature lists and pricing.
- Allow users to open the subscription plan modal from billing and account pages via the 'View all plans' and 'Upgrade now' buttons.

Enhancements:
- Track upgrade intent via PostHog events from the subscription modal and provide toast feedback for plan selection actions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a subscription plan management modal enabling users to view and compare available plans (Open Source, Pro, Team, Enterprise) from the billing page.
  * Users can toggle annual billing for Pro and Team plans and initiate upgrades with instant confirmation feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->