### PR TITLE
feat: resend invite email with magic link sign-in flow [#236]

### DIFF
--- a/apps/platform/app/(auth)/invite/page.tsx
+++ b/apps/platform/app/(auth)/invite/page.tsx
@@ -1,0 +1,10 @@
+import { InviteSignInClient } from "@/components/invite-sign-in-client";
+
+export default async function InvitePage({
+  searchParams,
+}: {
+  searchParams?: Promise<{ email?: string }>;
+}) {
+  const email = (await searchParams)?.email ?? "";
+  return <InviteSignInClient email={email} />;
+}

--- a/apps/platform/app/(backend)/auth/invite-callback/route.ts
+++ b/apps/platform/app/(backend)/auth/invite-callback/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server'
+import { createClient } from '@/utils/supabase/server'
+
+export async function GET(request: Request) {
+  const { searchParams, origin } = new URL(request.url)
+  const code = searchParams.get('code')
+
+  if (code) {
+    const supabase = await createClient()
+    const { error } = await supabase.auth.exchangeCodeForSession(code)
+    if (!error) {
+      return NextResponse.redirect(`${origin}/account/billing`)
+    }
+  }
+
+  return NextResponse.redirect(`${origin}/auth/auth-code-error`)
+}

--- a/apps/platform/app/(platform)/account/members/page.tsx
+++ b/apps/platform/app/(platform)/account/members/page.tsx
@@ -1,11 +1,36 @@
 "use client"
 
+import { useEffect, useState } from "react"
+import PrivatePageGuard from "@/components/private-page-guard"
 import { DataTable } from "@/components/members-table/data-table"
 import { columns } from "@/components/members-table/columns"
 import type { Member } from "@/components/members-table/columns"
-
-const members: Member[] = []
+import { inviteClientService } from "@/service/invite"
 
 export default function MembersPage() {
-  return <DataTable columns={columns} data={members} />
+  const [members, setMembers] = useState<Member[]>([])
+
+  useEffect(() => {
+    inviteClientService.getAll().then((invitations) => {
+      setMembers(
+        invitations.map((inv) => ({
+          id: inv.id,
+          username: inv.fullName,
+          lastActivity: inv.createdAt
+            ? new Date(inv.createdAt).toLocaleDateString()
+            : "—",
+          role: "Member",
+          seatStatus: "Assigned",
+        }))
+      )
+    })
+  }, [])
+
+  return (
+    <PrivatePageGuard>
+      <div className="p-6">
+        <DataTable columns={columns} data={members} />
+      </div>
+    </PrivatePageGuard>
+  )
 }

--- a/apps/platform/components/invite-sign-in-client.tsx
+++ b/apps/platform/components/invite-sign-in-client.tsx
@@ -2,10 +2,8 @@
 
 import { useState } from "react";
 import Image from "next/image";
-import { createClient } from "@/utils/supabase/client";
 import { Button } from "@thinkthroo/ui/components/button";
 import { Input } from "@thinkthroo/ui/components/input";
-import { toast } from "sonner";
 
 export function InviteSignInClient({ email: initialEmail }: { email: string }) {
   const [email, setEmail] = useState(initialEmail);
@@ -13,31 +11,7 @@ export function InviteSignInClient({ email: initialEmail }: { email: string }) {
   const [sent, setSent] = useState(false);
 
   async function handleSendLink() {
-    if (!email.trim()) {
-      toast.error("Email is required");
-      return;
-    }
-
-    setLoading(true);
-    try {
-      const supabase = createClient();
-      const { error } = await supabase.auth.signInWithOtp({
-        email,
-        options: {
-          emailRedirectTo: `${window.location.origin}/auth/callback?next=/account/billing`,
-        },
-      });
-
-      if (error) throw error;
-
-      setSent(true);
-      toast.success("Sign-in link sent! Check your inbox.");
-    } catch (err) {
-      const message = err instanceof Error ? err.message : "Failed to send sign-in link";
-      toast.error(message);
-    } finally {
-      setLoading(false);
-    }
+    window.location.href = `https://app.thinkthroo.com/login`;
   }
 
   return (

--- a/apps/platform/components/invite-sign-in-client.tsx
+++ b/apps/platform/components/invite-sign-in-client.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+import { createClient } from "@/utils/supabase/client";
+import { Button } from "@thinkthroo/ui/components/button";
+import { Input } from "@thinkthroo/ui/components/input";
+import { toast } from "sonner";
+
+export function InviteSignInClient({ email: initialEmail }: { email: string }) {
+  const [email, setEmail] = useState(initialEmail);
+  const [loading, setLoading] = useState(false);
+  const [sent, setSent] = useState(false);
+
+  async function handleSendLink() {
+    if (!email.trim()) {
+      toast.error("Email is required");
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const supabase = createClient();
+      const { error } = await supabase.auth.signInWithOtp({
+        email,
+        options: {
+          emailRedirectTo: `${window.location.origin}/auth/callback?next=/account/billing`,
+        },
+      });
+
+      if (error) throw error;
+
+      setSent(true);
+      toast.success("Sign-in link sent! Check your inbox.");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to send sign-in link";
+      toast.error(message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen w-full flex items-center justify-center bg-gray-50 dark:bg-gray-900">
+      <div className="w-full max-w-sm bg-white dark:bg-gray-800 rounded-2xl shadow-md p-8 flex flex-col items-center gap-6">
+        {/* Logo */}
+        <div className="flex items-center gap-2">
+          <Image
+            src="/logo.png"
+            alt="Think Throo"
+            width={32}
+            height={32}
+            className="rounded"
+            onError={(e) => { (e.target as HTMLImageElement).style.display = 'none' }}
+          />
+          <span className="font-bold text-lg tracking-tight text-gray-900 dark:text-white">
+            Think Throo
+          </span>
+        </div>
+
+        {sent ? (
+          <div className="text-center space-y-2">
+            <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
+              Check your email
+            </h2>
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              We sent a sign-in link to <strong>{email}</strong>. Click it to access your account.
+            </p>
+          </div>
+        ) : (
+          <>
+            <div className="text-center space-y-1">
+              <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
+                Welcome to Think Throo
+              </h2>
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                Sign in with your email to accept the invitation
+              </p>
+            </div>
+
+            <div className="w-full space-y-3">
+              <Input
+                type="email"
+                placeholder="you@example.com"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                className="w-full"
+                onKeyDown={(e) => e.key === "Enter" && handleSendLink()}
+              />
+              <Button
+                className="w-full bg-[#7c3aed] hover:bg-[#6d28d9] text-white"
+                onClick={handleSendLink}
+                disabled={loading}
+              >
+                {loading ? "Sending…" : "Sign in with email link"}
+              </Button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/platform/components/members-table/invite-member-modal.tsx
+++ b/apps/platform/components/members-table/invite-member-modal.tsx
@@ -10,6 +10,7 @@ import {
 import { Button } from "@thinkthroo/ui/components/button"
 import { Input } from "@thinkthroo/ui/components/input"
 import { toast } from "sonner"
+import { inviteClientService } from "@/service/invite"
 
 type Props = {
   open: boolean
@@ -33,13 +34,15 @@ export function InviteMemberModal({ open, onOpenChange }: Props) {
 
     setLoading(true)
     try {
-      // TODO: wire up the invite API call here
+      await inviteClientService.sendInvite({ fullName, email })
       toast.success(`Invite sent to ${email}`)
       setFullName("")
       setEmail("")
       onOpenChange(false)
-    } catch {
-      toast.error("Failed to send invite")
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to send invite"
+      toast.error(message)
+      console.error("[InviteMemberModal] sendInvite error:", err)
     } finally {
       setLoading(false)
     }

--- a/apps/platform/database/models/teamInvitation.ts
+++ b/apps/platform/database/models/teamInvitation.ts
@@ -1,0 +1,38 @@
+import { eq } from 'drizzle-orm';
+import { teamInvitations } from '../schemas';
+import { ThinkThrooDatabase } from '../type';
+
+export interface NewTeamInvitation {
+  fullName: string;
+  email: string;
+  invitedByUserId: string;
+  status?: string;
+}
+
+export class TeamInvitationModel {
+  private db: ThinkThrooDatabase;
+
+  constructor(db: ThinkThrooDatabase) {
+    this.db = db;
+  }
+
+  create = async (params: NewTeamInvitation) => {
+    const [result] = await this.db
+      .insert(teamInvitations)
+      .values(params)
+      .returning();
+
+    return result;
+  };
+
+  getByEmail = async (email: string) => {
+    return this.db
+      .select()
+      .from(teamInvitations)
+      .where(eq(teamInvitations.email, email));
+  };
+
+  getAll = async () => {
+    return this.db.select().from(teamInvitations);
+  };
+}

--- a/apps/platform/database/schemas/index.ts
+++ b/apps/platform/database/schemas/index.ts
@@ -11,5 +11,6 @@ export * from './challenge';
 export * from './payment';
 export * from './credit';
 export * from './invite';
+export * from './teamInvitation';
 export * from './courseProgress';
 export * from './skillStats';

--- a/apps/platform/database/schemas/teamInvitation.ts
+++ b/apps/platform/database/schemas/teamInvitation.ts
@@ -1,0 +1,29 @@
+import { pgTable, uuid, text, pgPolicy } from 'drizzle-orm/pg-core';
+import { sql } from 'drizzle-orm';
+import { timestamps } from './_helpers';
+
+export const teamInvitations = pgTable('team_invitations', {
+  id: uuid().defaultRandom().primaryKey().notNull(),
+  /** Full name of the invited person */
+  fullName: text('full_name').notNull(),
+  /** Email address of the invited person */
+  email: text('email').notNull(),
+  /** The user who sent the invite */
+  invitedByUserId: text('invited_by_user_id').notNull(),
+  /** Status: pending | accepted | expired */
+  status: text('status').notNull().default('pending'),
+  ...timestamps,
+}, (table) => [
+  pgPolicy('service role has full access to team_invitations', {
+    as: 'permissive',
+    for: 'all',
+    to: ['service_role'],
+    using: sql`true`,
+  }),
+  pgPolicy('authenticated users can view team_invitations', {
+    as: 'permissive',
+    for: 'select',
+    to: ['authenticated'],
+    using: sql`true`,
+  }),
+]);

--- a/apps/platform/lib/resend.ts
+++ b/apps/platform/lib/resend.ts
@@ -1,0 +1,3 @@
+import { Resend } from 'resend';
+
+export const resend = new Resend(process.env.RESEND_API_KEY);

--- a/apps/platform/package.json
+++ b/apps/platform/package.json
@@ -102,6 +102,7 @@
     "react-markdown": "^9.0.3",
     "react-resizable-panels": "^3.0.2",
     "recharts": "^2.15.3",
+    "resend": "^6.10.0",
     "sonner": "^2.0.5",
     "superjson": "^2.2.5",
     "tailwind-merge": "^3.3.0",

--- a/apps/platform/server/routers/lambda/index.ts
+++ b/apps/platform/server/routers/lambda/index.ts
@@ -3,10 +3,12 @@ import { documentRouter } from './document';
 import { organizationRouter } from './organization';
 import { installationRouter } from './installation';
 import { courseProgressRouter } from './courseProgress';
+import { inviteRouter } from './invite';
 
 export const lambdaRouter = router({
   document: documentRouter,
   organization: organizationRouter,
   installation: installationRouter,
   courseProgress: courseProgressRouter,
+  invite: inviteRouter,
 });export type LambdaRouter = typeof lambdaRouter;

--- a/apps/platform/server/routers/lambda/invite.ts
+++ b/apps/platform/server/routers/lambda/invite.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod';
+import { authedProcedure, router } from '@/lib/trpc/lambda';
+import { serverDatabase } from '@/lib/trpc/lambda/middleware';
+import { InviteService } from '@/server/service/invite';
+
+const inviteProcedure = authedProcedure
+  .use(serverDatabase)
+  .use(async (opts) => {
+    const { ctx } = opts;
+    return opts.next({
+      ctx: {
+        ...ctx,
+        inviteService: new InviteService(ctx.serverDB, ctx.userId),
+      },
+    });
+  });
+
+export const inviteRouter = router({
+  getAll: inviteProcedure.query(async ({ ctx }) => {
+    return ctx.inviteService.getAll();
+  }),
+
+  sendInvite: inviteProcedure
+    .input(
+      z.object({
+        fullName: z.string().min(1),
+        email: z.string().email(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      return ctx.inviteService.sendInvite({
+        fullName: input.fullName,
+        email: input.email,
+      });
+    }),
+});

--- a/apps/platform/server/service/invite/index.ts
+++ b/apps/platform/server/service/invite/index.ts
@@ -1,0 +1,52 @@
+import { resend } from '@/lib/resend';
+import { TeamInvitationModel } from '@/database/models/teamInvitation';
+import { ThinkThrooDatabase } from '@/database/type';
+
+export class InviteService {
+  private teamInvitationModel: TeamInvitationModel;
+
+  constructor(db: ThinkThrooDatabase, private userId: string) {
+    this.teamInvitationModel = new TeamInvitationModel(db);
+  }
+
+  async getAll() {
+    return this.teamInvitationModel.getAll();
+  }
+
+  async sendInvite({ fullName, email }: { fullName: string; email: string }) {
+    const { data, error } = await resend.emails.send({
+      from: 'Think Throo <onboarding@resend.dev>',
+      to: [email],
+      subject: "You've been invited to join a team on Think Throo",
+      html: `
+        <div style="font-family: sans-serif; max-width: 480px; margin: 0 auto;">
+          <h2>Hi ${fullName},</h2>
+          <p>You've been invited to join a team on <strong>Think Throo</strong>.</p>
+          <p>Click the button below to accept the invitation and get started.</p>
+          <a
+          href="${process.env.NEXT_PUBLIC_SITE_URL ?? 'https://app.thinkthroo.com'}/invite?email=${encodeURIComponent(email)}"
+            style="display:inline-block;padding:12px 24px;background:#7c3aed;color:#fff;border-radius:8px;text-decoration:none;font-weight:600;"
+          >
+            Accept Invitation
+          </a>
+          <p style="margin-top:24px;color:#6b7280;font-size:13px;">
+            If you weren't expecting this invite, you can safely ignore this email.
+          </p>
+        </div>
+      `,
+    });
+
+    if (error) {
+      throw new Error(error.message);
+    }
+
+    await this.teamInvitationModel.create({
+      fullName,
+      email,
+      invitedByUserId: this.userId,
+      status: 'pending',
+    });
+
+    return data;
+  }
+}

--- a/apps/platform/server/service/invite/index.ts
+++ b/apps/platform/server/service/invite/index.ts
@@ -15,7 +15,7 @@ export class InviteService {
 
   async sendInvite({ fullName, email }: { fullName: string; email: string }) {
     const { data, error } = await resend.emails.send({
-      from: 'Think Throo <onboarding@resend.dev>',
+      from: 'Think Throo <invite@thinkthroo.com>',
       to: [email],
       subject: "You've been invited to join a team on Think Throo",
       html: `
@@ -24,7 +24,7 @@ export class InviteService {
           <p>You've been invited to join a team on <strong>Think Throo</strong>.</p>
           <p>Click the button below to accept the invitation and get started.</p>
           <a
-          href="${process.env.NEXT_PUBLIC_SITE_URL ?? 'https://app.thinkthroo.com'}/invite?email=${encodeURIComponent(email)}"
+          href="https://app.thinkthroo.com/login"
             style="display:inline-block;padding:12px 24px;background:#7c3aed;color:#fff;border-radius:8px;text-decoration:none;font-weight:600;"
           >
             Accept Invitation

--- a/apps/platform/service/invite/client.ts
+++ b/apps/platform/service/invite/client.ts
@@ -1,0 +1,13 @@
+import { lambdaClient } from '@/lib/trpc/client/lambda';
+
+export class InviteClientService {
+  getAll = async () => {
+    return lambdaClient.invite.getAll.query();
+  };
+
+  sendInvite = async (params: { fullName: string; email: string }) => {
+    return lambdaClient.invite.sendInvite.mutate(params);
+  };
+}
+
+export const inviteClientService = new InviteClientService();

--- a/apps/platform/service/invite/index.ts
+++ b/apps/platform/service/invite/index.ts
@@ -1,0 +1,1 @@
+export * from './client';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -334,6 +334,9 @@ importers:
       recharts:
         specifier: ^2.15.3
         version: 2.15.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      resend:
+        specifier: ^6.10.0
+        version: 6.10.0
       sonner:
         specifier: ^2.0.5
         version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -6273,6 +6276,9 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -9095,6 +9101,9 @@ packages:
 
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
+
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
   fast-string-truncated-width@3.0.3:
     resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
@@ -11926,6 +11935,9 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
+  postal-mime@2.7.4:
+    resolution: {integrity: sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==}
+
   postcss-load-config@6.0.1:
     resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
     engines: {node: '>= 18'}
@@ -12635,6 +12647,15 @@ packages:
   reselect@5.1.1:
     resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
+  resend@6.10.0:
+    resolution: {integrity: sha512-i7CwZpYj4Oho1RxsTpLcCUkO08+HiL4NXrm6jLJ2WzJ89UGI8eROSieLONJA3hnUrf1OYnCyfq5F6POnHUMv1Q==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@react-email/render': '*'
+    peerDependenciesMeta:
+      '@react-email/render':
+        optional: true
+
   resize-observer-polyfill@1.5.1:
     resolution: {integrity: sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==}
 
@@ -13052,6 +13073,9 @@ packages:
   standard-as-callback@2.1.0:
     resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
 
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
@@ -13241,6 +13265,9 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  svix@1.88.0:
+    resolution: {integrity: sha512-vm/JrrUd3bVyBE+3L33TIyVSs8gS5fYx7lrISvKlDJXTYX1ACH4REX8P1tHxsSKoZi/rvifM1t0XRc5Vc45THw==}
 
   swap-case@1.1.2:
     resolution: {integrity: sha512-BAmWG6/bx8syfc6qXPprof3Mn5vQgf5dwdUNJhsNqU9WdPt5P+ES/wQ5bxfijy8zwZgZZHslC3iAsxsuQMCzJQ==}
@@ -21210,6 +21237,8 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
+  '@stablelib/base64@1.0.1': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@standard-schema/utils@0.3.0': {}
@@ -24516,6 +24545,8 @@ snapshots:
   fast-levenshtein@2.0.6: {}
 
   fast-safe-stringify@2.1.1: {}
+
+  fast-sha256@1.3.0: {}
 
   fast-string-truncated-width@3.0.3: {}
 
@@ -27987,6 +28018,8 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
+  postal-mime@2.7.4: {}
+
   postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.6)(yaml@2.8.2):
     dependencies:
       lilconfig: 3.1.3
@@ -29041,6 +29074,11 @@ snapshots:
 
   reselect@5.1.1: {}
 
+  resend@6.10.0:
+    dependencies:
+      postal-mime: 2.7.4
+      svix: 1.88.0
+
   resize-observer-polyfill@1.5.1: {}
 
   resolve-from@4.0.0: {}
@@ -30088,6 +30126,11 @@ snapshots:
 
   standard-as-callback@2.1.0: {}
 
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
   statuses@2.0.2: {}
 
   std-env@3.10.0: {}
@@ -30323,6 +30366,11 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  svix@1.88.0:
+    dependencies:
+      standardwebhooks: 1.0.0
+      uuid: 10.0.0
 
   swap-case@1.1.2:
     dependencies:


### PR DESCRIPTION
## Summary by Sourcery

Introduce team invitation flow with magic-link sign-in and integrate it into the members area.

New Features:
- Add team invitations backend including database schema, model, service, and TRPC router to send and list invitations.
- Add client-side invite service and wire the invite member modal to send real invitations via email using Resend.
- Add invite landing page and sign-in client that sends Supabase magic-link sign-in emails for invited users.
- Display pending team invitations in the account members table within a guarded private page.

Enhancements:
- Improve invite modal error handling with surfaced error messages and console logging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Team member invitation flow: send invites by email and record pending invitations
  * Email-based one-time sign-in UI for invite recipients
  * Members dashboard now loads and displays real members with activity and roles
  * Invitation callback route to finalize invite sign-in

* **Improvements**
  * Clearer user-facing error toasts and improved invite form behavior
  * More robust handling of email input, loading, and confirmation states
<!-- end of auto-generated comment: release notes by coderabbit.ai -->