### PR TITLE
Revert "[#221] paddle env set"

### DIFF
--- a/apps/platform/server/service/organization/index.ts
+++ b/apps/platform/server/service/organization/index.ts
@@ -102,7 +102,7 @@ export class OrganizationService {
     if (!org?.paddleCustomerId) return [];
 
     const paddle = new Paddle(process.env.PADDLE_API_KEY!, {
-      environment: process.env.PADDLE_ENVIRONMENT === 'production' ? Environment.production : Environment.sandbox,
+      environment: process.env.NODE_ENV === 'production' ? Environment.production : Environment.sandbox,
     });
 
     // Collect transactions first
@@ -151,7 +151,7 @@ export class OrganizationService {
     }
 
     const paddle = new Paddle(process.env.PADDLE_API_KEY!, {
-      environment: process.env.PADDLE_ENVIRONMENT === 'production' ? Environment.production : Environment.sandbox,
+      environment: process.env.NODE_ENV === 'production' ? Environment.production : Environment.sandbox,
     });
     const updated = await paddle.subscriptions.cancel(sub.subscriptionId, {
       effectiveFrom: 'next_billing_period',


### PR DESCRIPTION
Reverts ramu-narasinga/thinkthroo#241

## Summary by Sourcery

Enhancements:
- Align Paddle client environment configuration back to NODE_ENV-based selection instead of using PADDLE_ENVIRONMENT.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved Paddle SDK configuration for better environment detection consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->