### PR TITLE
Add settings icon click handler to open MembersSettingsModal

### DIFF
--- a/apps/platform/app/(platform)/skills-library/page.tsx
+++ b/apps/platform/app/(platform)/skills-library/page.tsx
@@ -10,7 +10,12 @@ export default async function SkillsLibraryPage() {
 
   // Fetch stats from Supabase for all skills
   const statsModel = new SkillStatsModel(serverDB)
-  const allStats = await statsModel.getAll()
+  let allStats: Awaited<ReturnType<typeof statsModel.getAll>> = []
+  try {
+    allStats = await statsModel.getAll()
+  } catch (err) {
+    console.error("[SkillsLibraryPage] Failed to load skill stats:", err)
+  }
   const statsMap = Object.fromEntries(allStats.map((s) => [s.skillSlug, s]))
 
   const totalWeeklyDownloads = allStats.reduce(

--- a/apps/platform/components/members-table/data-table.tsx
+++ b/apps/platform/components/members-table/data-table.tsx
@@ -12,6 +12,9 @@ import {
 } from "@tanstack/react-table"
 import { RefreshCw, Settings } from "lucide-react"
 import { InviteMemberModal } from "@/components/members-table/invite-member-modal"
+import { MembersSettingsModal } from "@/components/members-table/members-settings-modal"
+import { useOrganizationStore } from "@/store/organization"
+import { organizationSelectors } from "@/store/organization/selectors"
 
 import {
   Table,
@@ -45,6 +48,8 @@ export function DataTable<TData, TValue>({
   const [globalFilter, setGlobalFilter] = React.useState("")
   const [lastUpdated] = React.useState<Date>(new Date())
   const [inviteOpen, setInviteOpen] = React.useState(false)
+  const [settingsOpen, setSettingsOpen] = React.useState(false)
+  const activeOrgId = useOrganizationStore(organizationSelectors.activeOrgId)
 
   const table = useReactTable({
     data,
@@ -132,9 +137,10 @@ export function DataTable<TData, TValue>({
             + Invite Member
           </Button>
           <InviteMemberModal open={inviteOpen} onOpenChange={setInviteOpen} />
-          <Button variant="outline" size="icon" className="h-9 w-9">
+          <Button variant="outline" size="icon" className="h-9 w-9" onClick={() => setSettingsOpen(true)}>
             <Settings className="w-4 h-4" />
           </Button>
+          <MembersSettingsModal open={settingsOpen} onOpenChange={setSettingsOpen} organizationId={activeOrgId} />
         </div>
       </div>
 

--- a/apps/platform/components/members-table/members-settings-modal.tsx
+++ b/apps/platform/components/members-table/members-settings-modal.tsx
@@ -1,0 +1,174 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@thinkthroo/ui/components/dialog"
+import { Button } from "@thinkthroo/ui/components/button"
+import { Label } from "@thinkthroo/ui/components/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@thinkthroo/ui/components/select"
+import { Switch } from "@thinkthroo/ui/components/switch"
+import { Loader2 } from "lucide-react"
+import { toast } from "sonner"
+import { organizationSettingsClientService } from "@/service/organizationSettings/client"
+
+type Props = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  organizationId: string | undefined
+}
+
+const DEFAULTS = {
+  defaultRole: "Member",
+  allowMemberInvites: false,
+  requireApproval: true,
+}
+
+export function MembersSettingsModal({ open, onOpenChange, organizationId }: Props) {
+  const [defaultRole, setDefaultRole] = useState(DEFAULTS.defaultRole)
+  const [allowMemberInvites, setAllowMemberInvites] = useState(DEFAULTS.allowMemberInvites)
+  const [requireApproval, setRequireApproval] = useState(DEFAULTS.requireApproval)
+  const [saving, setSaving] = useState(false)
+  const [loading, setLoading] = useState(false)
+
+  // Reset to defaults when modal closes so stale state never flashes
+  useEffect(() => {
+    if (!open) {
+      setDefaultRole(DEFAULTS.defaultRole)
+      setAllowMemberInvites(DEFAULTS.allowMemberInvites)
+      setRequireApproval(DEFAULTS.requireApproval)
+    }
+  }, [open])
+
+  // Load persisted settings whenever the modal opens
+  useEffect(() => {
+    if (!open || !organizationId) return
+
+    setLoading(true)
+    organizationSettingsClientService
+      .getByOrganization(organizationId)
+      .then((settings) => {
+        if (!settings) return
+        setDefaultRole(settings.memberDefaultRole ?? DEFAULTS.defaultRole)
+        setAllowMemberInvites(settings.allowMemberInvites ?? DEFAULTS.allowMemberInvites)
+        setRequireApproval(settings.requireMemberApproval ?? DEFAULTS.requireApproval)
+      })
+      .catch(() => toast.error("Failed to load member settings"))
+      .finally(() => setLoading(false))
+  }, [open, organizationId])
+
+  async function handleSave() {
+    if (!organizationId) {
+      toast.error("No active organization")
+      return
+    }
+    setSaving(true)
+    try {
+      await organizationSettingsClientService.upsert(organizationId, {
+        memberDefaultRole: defaultRole,
+        allowMemberInvites,
+        requireMemberApproval: requireApproval,
+      })
+      toast.success("Member settings saved")
+      onOpenChange(false)
+    } catch {
+      toast.error("Failed to save settings")
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const disabled = loading || saving
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md rounded-xl p-6">
+        <DialogHeader>
+          <DialogTitle>Member Settings</DialogTitle>
+          <DialogDescription>
+            Configure default behaviour for team members.
+          </DialogDescription>
+        </DialogHeader>
+
+        {loading ? (
+          <div className="flex items-center justify-center py-10">
+            <Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />
+          </div>
+        ) : (
+          <div className="space-y-5 mt-2">
+            {/* Default role */}
+            <div className="space-y-1.5">
+              <Label htmlFor="default-role">Default role for new members</Label>
+              <Select value={defaultRole} onValueChange={setDefaultRole} disabled={disabled}>
+                <SelectTrigger id="default-role" className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="Admin">Admin</SelectItem>
+                  <SelectItem value="Member">Member</SelectItem>
+                  <SelectItem value="Viewer">Viewer</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            {/* Allow member invites */}
+            <div className="flex items-center justify-between gap-4">
+              <div className="space-y-0.5">
+                <Label>Allow members to invite others</Label>
+                <p className="text-xs text-muted-foreground">
+                  Members (not just Admins) can send invitations.
+                </p>
+              </div>
+              <Switch
+                checked={allowMemberInvites}
+                onCheckedChange={setAllowMemberInvites}
+                disabled={disabled}
+              />
+            </div>
+
+            {/* Require approval */}
+            <div className="flex items-center justify-between gap-4">
+              <div className="space-y-0.5">
+                <Label>Require admin approval for new members</Label>
+                <p className="text-xs text-muted-foreground">
+                  Invited users must be approved before they gain access.
+                </p>
+              </div>
+              <Switch
+                checked={requireApproval}
+                onCheckedChange={setRequireApproval}
+                disabled={disabled}
+              />
+            </div>
+          </div>
+        )}
+
+        <div className="flex justify-end gap-2 mt-6">
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={disabled}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave} disabled={disabled}>
+            {saving ? (
+              <span className="flex items-center gap-1.5">
+                <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                Saving…
+              </span>
+            ) : (
+              "Save changes"
+            )}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/platform/database/migrations/0021_member_settings.sql
+++ b/apps/platform/database/migrations/0021_member_settings.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "organization_settings" ADD COLUMN "member_default_role" text DEFAULT 'Member' NOT NULL;--> statement-breakpoint
+ALTER TABLE "organization_settings" ADD COLUMN "allow_member_invites" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "organization_settings" ADD COLUMN "require_member_approval" boolean DEFAULT true NOT NULL;

--- a/apps/platform/database/models/organizationSettings.ts
+++ b/apps/platform/database/models/organizationSettings.ts
@@ -11,6 +11,9 @@ export interface OrganizationSettingsData {
   toneInstructions: string | null;
   pathFilters: string[];
   autoPauseAfterReviewedCommits: number;
+  memberDefaultRole: string;
+  allowMemberInvites: boolean;
+  requireMemberApproval: boolean;
 }
 
 export class OrganizationSettingsModel {

--- a/apps/platform/database/schemas/organizationSettings.ts
+++ b/apps/platform/database/schemas/organizationSettings.ts
@@ -32,6 +32,11 @@ export const organizationSettings = pgTable('organization_settings', {
   // Pause incremental reviews after N reviewed commits in a cycle (0 = always review)
   autoPauseAfterReviewedCommits: integer('auto_pause_after_reviewed_commits').default(5).notNull(),
 
+  // Member settings
+  memberDefaultRole: text('member_default_role').default('Member').notNull(),
+  allowMemberInvites: boolean('allow_member_invites').default(false).notNull(),
+  requireMemberApproval: boolean('require_member_approval').default(true).notNull(),
+
   createdAt: timestamp('created_at', { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
   updatedAt: timestamp('updated_at', { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
 }, (table) => [

--- a/apps/platform/server/routers/lambda/organizationSettings.ts
+++ b/apps/platform/server/routers/lambda/organizationSettings.ts
@@ -12,6 +12,9 @@ const settingsInput = z.object({
   toneInstructions: z.string().nullable().optional(),
   pathFilters: z.array(z.string()).optional(),
   autoPauseAfterReviewedCommits: z.number().int().min(0).optional(),
+  memberDefaultRole: z.string().optional(),
+  allowMemberInvites: z.boolean().optional(),
+  requireMemberApproval: z.boolean().optional(),
 });
 
 const organizationSettingsProcedure = authedProcedure

--- a/apps/platform/service/organizationSettings/client.ts
+++ b/apps/platform/service/organizationSettings/client.ts
@@ -9,6 +9,9 @@ export interface OrganizationSettingsInput {
   toneInstructions?: string | null;
   pathFilters?: string[];
   autoPauseAfterReviewedCommits?: number;
+  memberDefaultRole?: string;
+  allowMemberInvites?: boolean;
+  requireMemberApproval?: boolean;
 }
 
 export class OrganizationSettingsClientService {


### PR DESCRIPTION
## Summary by Sourcery

Add configurable member management settings and wire them to a new settings modal accessible from the members table.

New Features:
- Introduce a Member Settings modal to configure default roles and invite/approval behaviour for organization members.
- Expose organization-level member settings fields (default role, member invites, approval requirement) through the database schema, server router, and client service.

Bug Fixes:
- Guard skills library stats loading with error handling to avoid breaking the page when Supabase queries fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Members Settings modal so admins can configure default member role, invitation allowance, and approval requirement per organization.

* **Chores**
  * Added persistent organization settings (DB schema + API + client) to store the new member-related fields.

* **Other Changes**
  * Skills library page no longer loads weekly download stats; related fallbacks were removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->