### PR TITLE
Add lesson accordion

### DIFF
--- a/apps/platform/app/(platform)/analytics/page.tsx
+++ b/apps/platform/app/(platform)/analytics/page.tsx
@@ -26,7 +26,7 @@ import {
 import { useAnalyticsStore } from "@/store/analytics/store";
 import { useOrganizationStore } from "@/store/organization";
 import { organizationSelectors } from "@/store/organization/selectors";
-import { Loader2 } from "lucide-react";
+import { Skeleton } from "@thinkthroo/ui/components/skeleton";
 
 export default function AnalyticsPage() {
   const activeOrg = useOrganizationStore(organizationSelectors.activeOrg);
@@ -66,8 +66,37 @@ export default function AnalyticsPage() {
       <div className="p-8 space-y-6">
         {/* Loading state */}
         {!isFirstFetchFinished && isLoading && (
-          <div className="flex items-center justify-center py-20">
-            <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+          <div className="space-y-6">
+            {/* Summary cards skeleton */}
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <div key={i} className="bg-muted rounded-xl p-4 space-y-2">
+                  <Skeleton className="h-4 w-28" />
+                  <Skeleton className="h-8 w-16" />
+                </div>
+              ))}
+            </div>
+
+            {/* Chart skeletons */}
+            {Array.from({ length: 2 }).map((_, i) => (
+              <div key={i} className="bg-muted rounded-xl p-6 space-y-4">
+                <div className="space-y-1">
+                  <Skeleton className="h-5 w-48" />
+                  <Skeleton className="h-4 w-64" />
+                </div>
+                <Skeleton className="h-[220px] w-full" />
+              </div>
+            ))}
+
+            {/* Table skeleton */}
+            <div className="bg-muted rounded-xl p-6 space-y-4">
+              <Skeleton className="h-7 w-40" />
+              <div className="space-y-2">
+                {Array.from({ length: 5 }).map((_, i) => (
+                  <Skeleton key={i} className="h-10 w-full rounded-lg" />
+                ))}
+              </div>
+            </div>
           </div>
         )}
 

--- a/apps/platform/app/(platform)/architecture/components/sanity-course-sidebar.tsx
+++ b/apps/platform/app/(platform)/architecture/components/sanity-course-sidebar.tsx
@@ -21,19 +21,31 @@ export function SanityCourseSidebar({
   completedLessonSlugs = new Set(),
   onSelectLesson,
 }: SanityCourseSidebarProps) {
-  const [openChapters, setOpenChapters] = React.useState<string[]>(
-    chapters.length > 0 ? [chapters[0].title] : []
-  )
+  const [openChapter, setOpenChapter] = React.useState<string | null>(() => {
+    if (selectedLessonSlug) {
+      const match = chapters.find((ch) =>
+        ch.lessons.some((l) => l.slug === selectedLessonSlug)
+      )
+      if (match) return match.title
+    }
+    return chapters.length > 0 ? chapters[0].title : null
+  })
+
+  // Keep the open chapter in sync when the selected lesson changes from outside
+  React.useEffect(() => {
+    if (!selectedLessonSlug) return
+    const match = chapters.find((ch) =>
+      ch.lessons.some((l) => l.slug === selectedLessonSlug)
+    )
+    if (match) setOpenChapter(match.title)
+  }, [selectedLessonSlug, chapters])
+
   const [sidebarOpen, setSidebarOpen] = React.useState(true)
 
   const [isOpen, setIsOpen] = React.useState(true)
 
   const toggleChapter = (title: string) => {
-    setOpenChapters((prev) =>
-      prev.includes(title)
-        ? prev.filter((t) => t !== title)
-        : [...prev, title]
-    )
+    setOpenChapter((prev) => (prev === title ? null : title))
   }
 
   if (!isOpen) {
@@ -81,7 +93,7 @@ export function SanityCourseSidebar({
 
       <div className="py-2">
         {chapters.map((chapter) => {
-          const isChapterOpen = openChapters.includes(chapter.title)
+          const isChapterOpen = openChapter === chapter.title
 
           return (
             <Collapsible

--- a/apps/platform/app/(platform)/integrations/page.tsx
+++ b/apps/platform/app/(platform)/integrations/page.tsx
@@ -23,7 +23,7 @@ function IntegrationsContent() {
   const activeOrg = useOrganizationStore(organizationSelectors.activeOrg);
   const [slackIntegration, setSlackIntegration] =
     useState<SlackIntegration | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState(false);
   const [isDisconnecting, setIsDisconnecting] = useState(false);
 
   const fetchIntegration = useCallback(async () => {

--- a/apps/platform/app/(platform)/integrations/slack/page.tsx
+++ b/apps/platform/app/(platform)/integrations/slack/page.tsx
@@ -1,25 +1,67 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import PrivatePageGuard from "@/components/private-page-guard";
 import { toast } from "sonner";
+import { Skeleton } from "@thinkthroo/ui/components/skeleton";
+import { useOrganizationStore } from "@/store/organization";
+import { organizationSelectors } from "@/store/organization/selectors";
+import { lambdaClient } from "@/lib/trpc/client/lambda";
 
-function handleAddToSlack() {
-  const clientId = process.env.NEXT_PUBLIC_SLACK_CLIENT_ID;
-
-  if (!clientId) {
-    toast.error("Slack integration is not configured yet.");
-    return;
-  }
-
-  const scope = "incoming-webhook,chat:write";
-  const url = new URL("https://slack.com/oauth/v2/authorize");
-  url.searchParams.set("client_id", clientId);
-  url.searchParams.set("scope", scope);
-
-  window.location.href = url.toString();
+interface SlackIntegration {
+  id: string;
+  teamName: string;
+  channelName: string;
+  isActive: boolean;
 }
 
 export default function SlackIntegrationPage() {
+  const activeOrg = useOrganizationStore(organizationSelectors.activeOrg);
+  const isOrgReady = useOrganizationStore(organizationSelectors.isFirstFetchFinished);
+  const [slackIntegration, setSlackIntegration] = useState<SlackIntegration | null>(null);
+  const [showSkeleton, setShowSkeleton] = useState(true);
+
+  useEffect(() => {
+    if (!isOrgReady) return;
+    if (!activeOrg?.id) {
+      setShowSkeleton(false);
+      return;
+    }
+    let cancelled = false;
+    lambdaClient.slack.getIntegration
+      .query({ organizationId: activeOrg.id })
+      .then((result) => {
+        if (!cancelled) {
+          setSlackIntegration(result as SlackIntegration | null);
+          setShowSkeleton(false);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setShowSkeleton(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [isOrgReady, activeOrg?.id]);
+
+  function handleAddToSlack() {
+    const clientId = process.env.NEXT_PUBLIC_SLACK_CLIENT_ID;
+    if (!clientId) {
+      toast.error("Slack integration is not configured yet.");
+      return;
+    }
+    if (!activeOrg?.id) {
+      toast.error("Please select an organization first.");
+      return;
+    }
+    const scope = "incoming-webhook,chat:write";
+    const url = new URL("https://slack.com/oauth/v2/authorize");
+    url.searchParams.set("client_id", clientId);
+    url.searchParams.set("scope", scope);
+    url.searchParams.set("state", activeOrg.id);
+    window.location.href = url.toString();
+  }
+
   return (
     <PrivatePageGuard>
       <div className="p-8 space-y-6">
@@ -35,12 +77,34 @@ export default function SlackIntegrationPage() {
             Add the ThinkThroo bot to your Slack workspace to get notified about
             architecture validation results and pull request reviews.
           </p>
-          <button
-            onClick={handleAddToSlack}
-            className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:brightness-110 hover:scale-[1.02] transition-all"
-          >
-            Add to Slack
-          </button>
+
+          {showSkeleton ? (
+            <div className="space-y-3">
+              <div className="space-y-1.5">
+                <Skeleton className="h-4 w-24" />
+                <Skeleton className="h-4 w-36" />
+              </div>
+              <Skeleton className="h-9 w-28" />
+            </div>
+          ) : slackIntegration?.isActive ? (
+            <div className="space-y-2 text-sm">
+              <p>
+                <span className="text-muted-foreground">Workspace:</span>{" "}
+                <span className="font-medium">{slackIntegration.teamName}</span>
+              </p>
+              <p>
+                <span className="text-muted-foreground">Channel:</span>{" "}
+                <span className="font-medium">#{slackIntegration.channelName}</span>
+              </p>
+            </div>
+          ) : (
+            <button
+              onClick={handleAddToSlack}
+              className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:brightness-110 hover:scale-[1.02] transition-all"
+            >
+              Add to Slack
+            </button>
+          )}
         </div>
       </div>
     </PrivatePageGuard>

--- a/apps/platform/app/(platform)/skills-library/page.tsx
+++ b/apps/platform/app/(platform)/skills-library/page.tsx
@@ -10,7 +10,12 @@ export default async function SkillsLibraryPage() {
 
   // Fetch stats from Supabase for all skills
   const statsModel = new SkillStatsModel(serverDB)
-  const allStats = await statsModel.getAll()
+  let allStats: Awaited<ReturnType<typeof statsModel.getAll>> = []
+  try {
+    allStats = await statsModel.getAll()
+  } catch (err) {
+    console.warn("Failed to fetch skill stats:", err)
+  }
   const statsMap = Object.fromEntries(allStats.map((s) => [s.skillSlug, s]))
 
   const totalWeeklyDownloads = allStats.reduce(

--- a/apps/platform/instrumentation.ts
+++ b/apps/platform/instrumentation.ts
@@ -1,26 +1,26 @@
-import { BatchLogRecordProcessor, LoggerProvider } from "@opentelemetry/sdk-logs";
-import { OTLPLogExporter } from "@opentelemetry/exporter-logs-otlp-http";
 import { logs } from "@opentelemetry/api-logs";
-import { resourceFromAttributes } from "@opentelemetry/resources";
-
-// Created outside register() so it can be exported and flushed in route handlers
-export const loggerProvider = new LoggerProvider({
-  resource: resourceFromAttributes({ "service.name": "thinkthroo-platform" }),
-  processors: [
-    new BatchLogRecordProcessor(
-      new OTLPLogExporter({
-        url: "https://us.i.posthog.com/i/v1/logs",
-        headers: {
-          Authorization: `Bearer ${process.env.NEXT_PUBLIC_POSTHOG_KEY}`,
-          "Content-Type": "application/json",
-        },
-      })
-    ),
-  ],
-});
 
 export async function register() {
   if (process.env.NEXT_RUNTIME === "nodejs") {
+    const { BatchLogRecordProcessor, LoggerProvider } = await import("@opentelemetry/sdk-logs");
+    const { OTLPLogExporter } = await import("@opentelemetry/exporter-logs-otlp-http");
+    const { resourceFromAttributes } = await import("@opentelemetry/resources");
+
+    const loggerProvider = new LoggerProvider({
+      resource: resourceFromAttributes({ "service.name": "thinkthroo-platform" }),
+      processors: [
+        new BatchLogRecordProcessor(
+          new OTLPLogExporter({
+            url: "https://us.i.posthog.com/i/v1/logs",
+            headers: {
+              Authorization: `Bearer ${process.env.NEXT_PUBLIC_POSTHOG_KEY}`,
+              "Content-Type": "application/json",
+            },
+          })
+        ),
+      ],
+    });
+
     logs.setGlobalLoggerProvider(loggerProvider);
   }
 }


### PR DESCRIPTION
## Summary by Sourcery

Improve Slack and analytics integrations UX, make course sidebar chapter behavior lesson-aware, and harden skills library stats loading.

New Features:
- Show Slack workspace and channel details when an active Slack integration exists.
- Display skeleton placeholders in analytics and Slack integration pages while organization or analytics data is loading.

Bug Fixes:
- Keep the open chapter in the course sidebar synchronized with the currently selected lesson to prevent mismatched accordion state.
- Avoid crashing the skills library page when fetching skill statistics fails by falling back to empty stats.
- Ensure Slack OAuth state includes the active organization identifier and require an organization to be selected before starting Slack authorization.

Enhancements:
- Lazy-initialize OpenTelemetry logging only when running on the Node.js runtime to reduce unnecessary imports.
- Disable eager Slack integration loading on the integrations overview page to avoid redundant initial loading state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved loading states with skeleton placeholders on analytics and Slack integration pages.
  * Added organization awareness to Slack integration setup.

* **Bug Fixes**
  * Added error handling for skills stats retrieval.

* **Refactor**
  * Optimized sidebar chapter navigation behavior.
  * Restructured Slack integration initialization.
  * Enhanced logging infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->