### PR TITLE
updated-skillslibrary-analytics

### DIFF
--- a/apps/platform/app/(platform)/analytics/page.tsx
+++ b/apps/platform/app/(platform)/analytics/page.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { useEffect } from "react";
-import PrivatePageGuard from "@/components/private-page-guard";
 import {
   Table,
   TableHeader,
@@ -14,8 +12,6 @@ import {
 import {
   LineChart,
   Line,
-  BarChart,
-  Bar,
   XAxis,
   YAxis,
   CartesianGrid,
@@ -23,291 +19,124 @@ import {
   ResponsiveContainer,
 } from "recharts";
 
-import { useAnalyticsStore } from "@/store/analytics/store";
-import { useOrganizationStore } from "@/store/organization";
-import { organizationSelectors } from "@/store/organization/selectors";
-import { Loader2 } from "lucide-react";
+import { Skeleton } from "@thinkthroo/ui/components/skeleton";
+import { useState, useEffect } from "react";
+
+const weeklyMetrics = [
+  { week: "12/7", prsMerged: 1, humanReviews: 3, reviewCycles: 1.2, linesAdded: 120, linesDeleted: 30, medianLinesPR: 80 },
+  { week: "12/14", prsMerged: 2, humanReviews: 5, reviewCycles: 1.5, linesAdded: 240, linesDeleted: 60, medianLinesPR: 110 },
+  { week: "12/21", prsMerged: 1, humanReviews: 4, reviewCycles: 1.1, linesAdded: 180, linesDeleted: 40, medianLinesPR: 95 },
+  { week: "12/28", prsMerged: 3, humanReviews: 6, reviewCycles: 1.8, linesAdded: 320, linesDeleted: 90, medianLinesPR: 130 },
+  { week: "1/4", prsMerged: 2, humanReviews: 5, reviewCycles: 1.4, linesAdded: 260, linesDeleted: 70, medianLinesPR: 115 },
+  { week: "1/11", prsMerged: 4, humanReviews: 7, reviewCycles: 2.0, linesAdded: 410, linesDeleted: 120, medianLinesPR: 150 },
+];
 
 export default function AnalyticsPage() {
-  const activeOrg = useOrganizationStore(organizationSelectors.activeOrg);
-  const weeklyMetrics = useAnalyticsStore((s) => s.weeklyMetrics);
-  const hotspotFiles = useAnalyticsStore((s) => s.hotspotFiles);
-  const topViolatedRules = useAnalyticsStore((s) => s.topViolatedRules);
-  const isWeeklyLoading = useAnalyticsStore((s) => s.isWeeklyLoading);
-  const isHotspotsLoading = useAnalyticsStore((s) => s.isHotspotsLoading);
-  const isFirstFetchFinished = useAnalyticsStore((s) => s.isFirstFetchFinished);
-  const fetchAll = useAnalyticsStore((s) => s.fetchAll);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    if (activeOrg?.id) {
-      fetchAll(activeOrg.id);
-    }
-  }, [activeOrg?.id, fetchAll]);
+    const t = setTimeout(() => setLoading(false), 1500);
+    return () => clearTimeout(t);
+  }, []);
 
-  const isLoading = isWeeklyLoading || isHotspotsLoading;
-  const isEmpty = isFirstFetchFinished && weeklyMetrics.length === 0;
+  if (loading) {
+    return (
+      <div className="p-8 space-y-6">
+        {/* Chart skeleton */}
+        <div className="bg-muted rounded-xl p-6 space-y-4">
+          <Skeleton className="h-5 w-40" />
+          <Skeleton className="h-4 w-56" />
+          <Skeleton className="h-[220px] w-full rounded-lg" />
+        </div>
 
-  // Summary stats
-  const totalPrs = weeklyMetrics.reduce((sum, m) => sum + m.prsReviewed, 0);
-  const totalViolations = weeklyMetrics.reduce((sum, m) => sum + m.totalViolations, 0);
-  const avgScore =
-    weeklyMetrics.length > 0
-      ? (weeklyMetrics.reduce((sum, m) => sum + m.avgComplianceScore, 0) / weeklyMetrics.length).toFixed(1)
-      : "—";
-  const overallCleanRate =
-    totalPrs > 0
-      ? Math.round(
-          (weeklyMetrics.reduce((sum, m) => sum + m.cleanPrs, 0) / totalPrs) * 100
-        )
-      : null;
+        {/* Table skeleton */}
+        <div className="bg-muted rounded-xl p-6 space-y-4">
+          <Skeleton className="h-6 w-48" />
+          <div className="flex gap-4 mb-2">
+            {Array.from({ length: 7 }).map((_, i) => (
+              <Skeleton key={i} className="h-4 flex-1" />
+            ))}
+          </div>
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={i} className="flex gap-4">
+              {Array.from({ length: 7 }).map((_, j) => (
+                <Skeleton key={j} className="h-9 flex-1 rounded-lg" />
+              ))}
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
 
   return (
-    <PrivatePageGuard>
-      <div className="p-8 space-y-6">
-        {/* Loading state */}
-        {!isFirstFetchFinished && isLoading && (
-          <div className="flex items-center justify-center py-20">
-            <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-          </div>
-        )}
+    <div className="p-8 space-y-6">
+      {/* PRs merged graph */}
+      <div className="bg-muted rounded-xl p-6">
+        <div className="mb-4">
+          <h2 className="text-lg font-semibold">Pull Requests</h2>
+          <p className="text-sm text-muted-foreground">PRs merged per week</p>
+        </div>
 
-        {/* Empty state */}
-        {isEmpty && (
-          <div className="bg-muted rounded-xl p-12 text-center">
-            <h2 className="text-lg font-semibold mb-2">No analytics data yet</h2>
-            <p className="text-sm text-muted-foreground">
-              Analytics will appear here once the ThinkThroo bot reviews PRs in your repositories.
-            </p>
-          </div>
-        )}
+        <div className="h-[220px]">
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={weeklyMetrics} margin={{ top: 10, right: 20, left: -10, bottom: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" vertical={false} />
+              <XAxis dataKey="week" tickLine={false} axisLine={false} />
+              <YAxis tickLine={false} axisLine={false} domain={[0, 4]} ticks={[0, 1, 2, 3, 4]} />
+              <Tooltip />
+              <Line
+                type="monotone"
+                dataKey="prsMerged"
+                stroke="#000000"
+                strokeWidth={2}
+                dot={{
+                  r: 4,
+                  fill: "#fff",
+                  stroke: "#000000",
+                  strokeWidth: 2,
+                }}
+                activeDot={{ r: 6 }}
+                isAnimationActive={false}
+              />
 
-        {/* Dashboard content */}
-        {isFirstFetchFinished && weeklyMetrics.length > 0 && (
-          <>
-            {/* Summary cards */}
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-              <div className="bg-muted rounded-xl p-4">
-                <p className="text-sm text-muted-foreground">PRs Reviewed</p>
-                <p className="text-2xl font-semibold">{totalPrs}</p>
-              </div>
-              <div className="bg-muted rounded-xl p-4">
-                <p className="text-sm text-muted-foreground">Total Violations</p>
-                <p className="text-2xl font-semibold">{totalViolations}</p>
-              </div>
-              <div className="bg-muted rounded-xl p-4">
-                <p className="text-sm text-muted-foreground">Avg Compliance Score</p>
-                <p className="text-2xl font-semibold">{avgScore}</p>
-              </div>
-              <div className="bg-muted rounded-xl p-4">
-                <p className="text-sm text-muted-foreground">Clean PR Rate</p>
-                <p className="text-2xl font-semibold">
-                  {overallCleanRate !== null ? `${overallCleanRate}%` : "—"}
-                </p>
-              </div>
-            </div>
-
-            {/* Compliance score trend */}
-            <div className="bg-muted rounded-xl p-6">
-              <div className="mb-4">
-                <h2 className="text-lg font-semibold">Compliance Score Trend</h2>
-                <p className="text-sm text-muted-foreground">
-                  Average architecture compliance score per week
-                </p>
-              </div>
-
-              <div className="h-[220px]">
-                <ResponsiveContainer width="100%" height="100%">
-                  <LineChart
-                    data={weeklyMetrics}
-                    margin={{ top: 10, right: 20, left: -10, bottom: 0 }}
-                  >
-                    <CartesianGrid strokeDasharray="3 3" vertical={false} />
-                    <XAxis dataKey="week" tickLine={false} axisLine={false} />
-                    <YAxis
-                      tickLine={false}
-                      axisLine={false}
-                      domain={[0, 100]}
-                    />
-                    <Tooltip />
-                    <Line
-                      type="monotone"
-                      dataKey="avgComplianceScore"
-                      name="Compliance Score"
-                      stroke="#000000"
-                      strokeWidth={2}
-                      dot={{
-                        r: 4,
-                        fill: "#fff",
-                        stroke: "#000000",
-                        strokeWidth: 2,
-                      }}
-                      activeDot={{ r: 6 }}
-                      isAnimationActive={false}
-                    />
-                  </LineChart>
-                </ResponsiveContainer>
-              </div>
-            </div>
-
-            {/* Violation trend */}
-            <div className="bg-muted rounded-xl p-6">
-              <div className="mb-4">
-                <h2 className="text-lg font-semibold">Violation Trend</h2>
-                <p className="text-sm text-muted-foreground">
-                  Total architecture violations per week
-                </p>
-              </div>
-
-              <div className="h-[220px]">
-                <ResponsiveContainer width="100%" height="100%">
-                  <BarChart
-                    data={weeklyMetrics}
-                    margin={{ top: 10, right: 20, left: -10, bottom: 0 }}
-                  >
-                    <CartesianGrid strokeDasharray="3 3" vertical={false} />
-                    <XAxis dataKey="week" tickLine={false} axisLine={false} />
-                    <YAxis tickLine={false} axisLine={false} />
-                    <Tooltip />
-                    <Bar
-                      dataKey="totalViolations"
-                      name="Violations"
-                      fill="#000000"
-                      radius={[4, 4, 0, 0]}
-                    />
-                  </BarChart>
-                </ResponsiveContainer>
-              </div>
-            </div>
-
-            {/* Weekly metrics table */}
-            <div className="bg-muted rounded-xl p-6">
-              <h2 className="text-2xl font-semibold mb-6">Weekly Metrics</h2>
-
-              <Table className="border-separate border-spacing-y-2">
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>WEEK ↑</TableHead>
-                    <TableHead className="text-center">PRS REVIEWED</TableHead>
-                    <TableHead className="text-center">VIOLATIONS</TableHead>
-                    <TableHead className="text-center">AVG SCORE</TableHead>
-                    <TableHead className="text-center">CLEAN PRS</TableHead>
-                    <TableHead className="text-center">CLEAN PR RATE</TableHead>
-                  </TableRow>
-                </TableHeader>
-
-                <TableBody>
-                  {weeklyMetrics.map((row) => (
-                    <TableRow key={row.week} className="hover:bg-transparent">
-                      <TableCell className="bg-white rounded-l-lg shadow-sm font-medium">
-                        {row.week}
-                      </TableCell>
-                      <TableCell className="bg-white shadow-sm text-center">
-                        {row.prsReviewed}
-                      </TableCell>
-                      <TableCell className="bg-white shadow-sm text-center">
-                        {row.totalViolations}
-                      </TableCell>
-                      <TableCell className="bg-white shadow-sm text-center">
-                        {row.avgComplianceScore}
-                      </TableCell>
-                      <TableCell className="bg-white shadow-sm text-center">
-                        {row.cleanPrs}
-                      </TableCell>
-                      <TableCell className="bg-white rounded-r-lg shadow-sm text-center">
-                        {row.cleanPrRate}%
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            </div>
-
-            {/* Hotspot files */}
-            {hotspotFiles.length > 0 && (
-              <div className="bg-muted rounded-xl p-6">
-                <h2 className="text-2xl font-semibold mb-2">Violation Hotspots</h2>
-                <p className="text-sm text-muted-foreground mb-6">
-                  Files with the most architecture violations
-                </p>
-
-                <Table className="border-separate border-spacing-y-2">
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead>FILE</TableHead>
-                      <TableHead className="text-center">VIOLATIONS</TableHead>
-                      <TableHead className="text-center">AVG SCORE</TableHead>
-                      <TableHead className="text-center">PRS AFFECTED</TableHead>
-                    </TableRow>
-                  </TableHeader>
-
-                  <TableBody>
-                    {hotspotFiles.map((file) => (
-                      <TableRow
-                        key={file.filename}
-                        className="hover:bg-transparent"
-                      >
-                        <TableCell className="bg-white rounded-l-lg shadow-sm font-mono text-sm">
-                          {file.filename}
-                        </TableCell>
-                        <TableCell className="bg-white shadow-sm text-center">
-                          {file.totalViolations}
-                        </TableCell>
-                        <TableCell className="bg-white shadow-sm text-center">
-                          {file.avgScore}
-                        </TableCell>
-                        <TableCell className="bg-white rounded-r-lg shadow-sm text-center">
-                          {file.prCount}
-                        </TableCell>
-                      </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
-              </div>
-            )}
-
-            {/* Top violated rules */}
-            {topViolatedRules.length > 0 && (
-              <div className="bg-muted rounded-xl p-6">
-                <h2 className="text-2xl font-semibold mb-2">
-                  Most Violated Architecture Rules
-                </h2>
-                <p className="text-sm text-muted-foreground mb-6">
-                  Architecture docs that are most frequently violated
-                </p>
-
-                <Table className="border-separate border-spacing-y-2">
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead>RULE</TableHead>
-                      <TableHead className="text-center">VIOLATIONS</TableHead>
-                      <TableHead className="text-center">PRS AFFECTED</TableHead>
-                    </TableRow>
-                  </TableHeader>
-
-                  <TableBody>
-                    {topViolatedRules.map((rule) => (
-                      <TableRow
-                        key={rule.ruleName}
-                        className="hover:bg-transparent"
-                      >
-                        <TableCell className="bg-white rounded-l-lg shadow-sm font-medium">
-                          {rule.ruleName}
-                        </TableCell>
-                        <TableCell className="bg-white shadow-sm text-center">
-                          {rule.violationCount}
-                        </TableCell>
-                        <TableCell className="bg-white rounded-r-lg shadow-sm text-center">
-                          {rule.prCount}
-                        </TableCell>
-                      </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
-              </div>
-            )}
-          </>
-        )}
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
       </div>
-    </PrivatePageGuard>
+
+      {/* Analytics table */}
+      <div className="bg-muted rounded-xl p-6">
+        <h2 className="text-2xl font-semibold mb-6">Weekly Metrics</h2>
+
+        <Table className="border-separate border-spacing-y-2">
+          <TableHeader>
+            <TableRow>
+              <TableHead>WEEK ↑</TableHead>
+              <TableHead className="text-center">PRS MERGED</TableHead>
+              <TableHead className="text-center">HUMAN REVIEWS</TableHead>
+              <TableHead className="text-center">REVIEW CYCLES</TableHead>
+              <TableHead className="text-center">LINES ADDED</TableHead>
+              <TableHead className="text-center">LINES DELETED</TableHead>
+              <TableHead className="text-center">MEDIAN LINES/PR</TableHead>
+            </TableRow>
+          </TableHeader>
+
+          <TableBody>
+            {weeklyMetrics.map((row) => (
+              <TableRow key={row.week} className="hover:bg-transparent">
+                <TableCell className="bg-white rounded-l-lg shadow-sm font-medium">{row.week}</TableCell>
+                <TableCell className="bg-white shadow-sm text-center">{row.prsMerged}</TableCell>
+                <TableCell className="bg-white shadow-sm text-center">{row.humanReviews}</TableCell>
+                <TableCell className="bg-white shadow-sm text-center">{row.reviewCycles.toFixed(1)}</TableCell>
+                <TableCell className="bg-white shadow-sm text-center">{row.linesAdded}</TableCell>
+                <TableCell className="bg-white shadow-sm text-center">{row.linesDeleted}</TableCell>
+                <TableCell className="bg-white rounded-r-lg shadow-sm text-center">{row.medianLinesPR}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
   );
 }

--- a/apps/platform/app/(platform)/dashboard/page.tsx
+++ b/apps/platform/app/(platform)/dashboard/page.tsx
@@ -1,21 +1,126 @@
-"use client";
+"use client"
 
-import PrivatePageGuard from "@/components/private-page-guard";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@thinkthroo/ui/components/card"
+import { Progress } from "@thinkthroo/ui/components/progress"
+import { Button } from "@thinkthroo/ui/components/button"
+import { courseData, getCategoryProgress } from "@/lib/course-data"
+import { BookOpen, Code2, PlayCircle, Clock, Trophy } from "lucide-react"
+import Link from "next/link"
 
 export default function DashboardPage() {
-  return (
-    <PrivatePageGuard>
-      <div className="p-8 space-y-6">
-        <h1 className="text-2xl font-semibold">Dashboard</h1>
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-          <div className="bg-muted rounded-xl p-6 h-32" />
-          <div className="bg-muted rounded-xl p-6 h-32" />
-          <div className="bg-muted rounded-xl p-6 h-32" />
-        </div>
-        <div className="bg-muted rounded-xl p-6 h-48" />
-        <div className="bg-muted rounded-xl p-6 h-48" />
-      </div>
-    </PrivatePageGuard>
-  );
-}
+  const totalLessons = courseData.reduce(
+    (acc, cat) =>
+      acc + cat.modules.reduce((mAcc, m) => mAcc + m.chapters.reduce((chAcc, ch) => chAcc + ch.lessons.length, 0), 0),
+    0,
+  )
 
+  const completedLessons = courseData.reduce(
+    (acc, cat) =>
+      acc +
+      cat.modules.reduce(
+        (mAcc, m) => mAcc + m.chapters.reduce((chAcc, ch) => chAcc + ch.lessons.filter((l) => l.completed).length, 0),
+        0,
+      ),
+    0,
+  )
+
+  const overallProgress = Math.round((completedLessons / totalLessons) * 100)
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">Welcome back!</h1>
+        <p className="text-muted-foreground mt-1">Continue your learning journey</p>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-4">
+              <Card>
+                <CardHeader className="pb-2">
+                  <CardDescription>Overall Progress</CardDescription>
+                  <CardTitle className="text-3xl">{overallProgress}%</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <Progress value={overallProgress} className="h-2" />
+                </CardContent>
+              </Card>
+
+              <Card>
+                <CardHeader className="pb-2">
+                  <CardDescription>Lessons Completed</CardDescription>
+                  <CardTitle className="text-3xl">
+                    {completedLessons}/{totalLessons}
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="flex items-center gap-2 text-muted-foreground">
+                  <BookOpen className="h-4 w-4" />
+                  <span className="text-sm">lessons</span>
+                </CardContent>
+              </Card>
+
+              <Card>
+                <CardHeader className="pb-2">
+                  <CardDescription>Time Invested</CardDescription>
+                  <CardTitle className="text-3xl">2.5h</CardTitle>
+                </CardHeader>
+                <CardContent className="flex items-center gap-2 text-muted-foreground">
+                  <Clock className="h-4 w-4" />
+                  <span className="text-sm">this week</span>
+                </CardContent>
+              </Card>
+
+              <Card>
+                <CardHeader className="pb-2">
+                  <CardDescription>Achievements</CardDescription>
+                  <CardTitle className="text-3xl">3</CardTitle>
+                </CardHeader>
+                <CardContent className="flex items-center gap-2 text-muted-foreground">
+                  <Trophy className="h-4 w-4" />
+                  <span className="text-sm">badges earned</span>
+                </CardContent>
+              </Card>
+      </div>
+
+      <div>
+        <h2 className="text-xl font-semibold mb-4">Continue Learning</h2>
+        <div className="grid gap-4 md:grid-cols-2">
+                {courseData.map((category) => {
+                  const progress = getCategoryProgress(category)
+                  const Icon = category.slug === "codebase-architecture" ? Code2 : BookOpen
+
+                  return (
+                    <Card key={category.id} className="group hover:shadow-md transition-shadow">
+                      <CardHeader>
+                        <div className="flex items-center gap-3">
+                          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                            <Icon className="h-5 w-5" />
+                          </div>
+                          <div className="flex-1">
+                            <CardTitle className="text-lg">{category.title}</CardTitle>
+                            <CardDescription>{category.modules.length} modules</CardDescription>
+                          </div>
+                        </div>
+                      </CardHeader>
+                      <CardContent className="space-y-4">
+                        <div className="space-y-2">
+                          <div className="flex justify-between text-sm">
+                            <span className="text-muted-foreground">Progress</span>
+                            <span className="font-medium">{progress}%</span>
+                          </div>
+                          <Progress value={progress} className="h-2" />
+                        </div>
+                        <Button asChild className="w-full">
+                          <Link href={`/learn/${category.slug}`}>
+                            <PlayCircle className="mr-2 h-4 w-4" />
+                            {progress === 0 ? "Start Learning" : "Continue"}
+                          </Link>
+                        </Button>
+                      </CardContent>
+                    </Card>
+                  )
+                })}
+        </div>
+      </div>
+    </div>
+  )
+  return <div />;
+}

--- a/apps/platform/app/(platform)/learn/dashboard/page.tsx
+++ b/apps/platform/app/(platform)/learn/dashboard/page.tsx
@@ -1,11 +1,6 @@
 "use client";
 import DashboardAltPage from "@/components/DashboardAlt";
-import PrivatePageGuard from "@/components/private-page-guard";
 
 export default function LearnDashboardPage() {
-  return (
-    <PrivatePageGuard>
-      <DashboardAltPage />
-    </PrivatePageGuard>
-  );
+  return <DashboardAltPage />;
 }

--- a/apps/platform/app/(platform)/skills-library/components/category-header.tsx
+++ b/apps/platform/app/(platform)/skills-library/components/category-header.tsx
@@ -1,11 +1,10 @@
-import { BookOpen, Download } from "lucide-react";
+import { BookOpen } from "lucide-react";
 
 interface CategoryHeaderProps {
   totalSkills: number;
-  totalWeeklyDownloads: number;
 }
 
-export function CategoryHeader({ totalSkills, totalWeeklyDownloads }: CategoryHeaderProps) {
+export function CategoryHeader({ totalSkills }: CategoryHeaderProps) {
   return (
     <div className="border-b border-border bg-background px-6 py-6">
       <div className="flex items-start justify-between">
@@ -16,10 +15,6 @@ export function CategoryHeader({ totalSkills, totalWeeklyDownloads }: CategoryHe
           </div>
           <div className="flex items-center gap-4 text-sm text-muted-foreground">
             <span>{totalSkills} {totalSkills === 1 ? "skill" : "skills"}</span>
-            <span className="flex items-center gap-1">
-              <Download className="h-3.5 w-3.5" />
-              {totalWeeklyDownloads.toLocaleString()} weekly downloads
-            </span>
           </div>
         </div>
       </div>

--- a/apps/platform/app/(platform)/skills-library/components/module-card.tsx
+++ b/apps/platform/app/(platform)/skills-library/components/module-card.tsx
@@ -2,16 +2,15 @@ import { type SanitySkill } from "@/lib/skill"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@thinkthroo/ui/components/card"
 import { Button } from "@thinkthroo/ui/components/button"
 import { Badge } from "@thinkthroo/ui/components/badge"
-import { Download, PlusCircle, Tag, Zap } from "lucide-react"
+import { PlusCircle } from "lucide-react"
 import Link from "next/link"
 
 interface ModuleCardProps {
   skill: SanitySkill
-  weeklyDownloads: number
 }
 
-export function ModuleCard({ skill, weeklyDownloads }: ModuleCardProps) {
-  const { title, description, slug, tags, skillsCount } = skill
+export function ModuleCard({ skill }: ModuleCardProps) {
+  const { title, description, slug, tags } = skill
 
   return (
     <Card className="group hover:shadow-md transition-shadow flex flex-col">
@@ -23,30 +22,17 @@ export function ModuleCard({ skill, weeklyDownloads }: ModuleCardProps) {
       </CardHeader>
 
       <CardContent className="flex flex-col flex-1 gap-4">
-        {/* Stats row */}
-        <div className="flex items-center gap-4 text-sm text-muted-foreground">
-          <div className="flex items-center gap-1.5">
-            <Zap className="h-4 w-4" />
-            <span>
-              {skillsCount ?? 1} {(skillsCount ?? 1) === 1 ? "skill" : "skills"}
-            </span>
-          </div>
-          <div className="flex items-center gap-1.5">
-            <Download className="h-4 w-4" />
-            <span>{weeklyDownloads.toLocaleString()} weekly</span>
-          </div>
-        </div>
-
         {/* Tags */}
-        {tags && tags.length > 0 && (
+        {tags && tags.length > 0 ? (
           <div className="flex flex-wrap gap-2">
             {tags.map((tag, index) => (
-              <Badge key={index} variant="secondary" className="flex items-center gap-1 text-xs">
-                <Tag className="h-3 w-3" />
+              <Badge key={index} variant="secondary" className="text-xs">
                 {tag.title}
               </Badge>
             ))}
           </div>
+        ) : (
+          <p className="text-xs text-muted-foreground">No tags</p>
         )}
 
         {/* CTA pinned to bottom */}

--- a/apps/platform/app/(platform)/skills-library/components/skills-grid.tsx
+++ b/apps/platform/app/(platform)/skills-library/components/skills-grid.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { type SanitySkill } from "@/lib/skill";
+import { ModuleCard } from "./module-card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@thinkthroo/ui/components/select";
+
+interface SkillsGridProps {
+  skills: SanitySkill[];
+}
+
+export function SkillsGrid({ skills }: SkillsGridProps) {
+  const [activeTag, setActiveTag] = useState<string>("all");
+
+  const allTags = useMemo(() => {
+    const seen = new Set<string>();
+    const tags: string[] = [];
+    for (const skill of skills) {
+      for (const tag of skill.tags ?? []) {
+        if (!seen.has(tag.title)) {
+          seen.add(tag.title);
+          tags.push(tag.title);
+        }
+      }
+    }
+    return tags;
+  }, [skills]);
+
+  const filtered = useMemo(
+    () =>
+      activeTag === "all"
+        ? skills
+        : skills.filter((s) => s.tags?.some((t) => t.title === activeTag)),
+    [skills, activeTag]
+  );
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Dropdown filter */}
+      <div className="flex items-center gap-3">
+        <span className="text-sm font-medium text-muted-foreground whitespace-nowrap">Filter by tags:</span>
+        <Select value={activeTag} onValueChange={setActiveTag}>
+          <SelectTrigger className="w-48">
+            <SelectValue placeholder="Select a tag" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All</SelectItem>
+            {allTags.map((tag) => (
+              <SelectItem key={tag} value={tag}>
+                {tag}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* Grid */}
+      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+        {filtered.map((skill) => (
+          <ModuleCard key={skill.slug} skill={skill} />
+        ))}
+      </div>
+
+      {filtered.length === 0 && (
+        <p className="text-sm text-muted-foreground">No skills match this tag.</p>
+      )}
+    </div>
+  );
+}

--- a/apps/platform/app/(platform)/skills-library/page.tsx
+++ b/apps/platform/app/(platform)/skills-library/page.tsx
@@ -1,16 +1,22 @@
 import { fetchAllSkills } from "@/lib/skill"
-import { serverDB } from "@/database/core/db-adaptor"
+import { getServerDB } from "@/database/core/db-adaptor"
 import { SkillStatsModel } from "@/database/models/skillStats"
 import { CategoryHeader } from "@/app/(platform)/skills-library/components/category-header"
-import { ModuleCard } from "@/app/(platform)/skills-library/components/module-card"
+import { SkillsGrid } from "@/app/(platform)/skills-library/components/skills-grid"
 
 export default async function SkillsLibraryPage() {
   // Fetch skills content from Sanity
   const skills = await fetchAllSkills()
 
   // Fetch stats from Supabase for all skills
-  const statsModel = new SkillStatsModel(serverDB)
-  const allStats = await statsModel.getAll()
+  let allStats: Awaited<ReturnType<SkillStatsModel["getAll"]>> = []
+  try {
+    const db = await getServerDB()
+    const statsModel = new SkillStatsModel(db)
+    allStats = await statsModel.getAll()
+  } catch (err) {
+    console.error("[SkillsLibraryPage] Failed to fetch skill stats:", err)
+  }
   const statsMap = Object.fromEntries(allStats.map((s) => [s.skillSlug, s]))
 
   const totalWeeklyDownloads = allStats.reduce(
@@ -22,18 +28,9 @@ export default async function SkillsLibraryPage() {
     <div className="page">
       <CategoryHeader
         totalSkills={skills.length}
-        totalWeeklyDownloads={totalWeeklyDownloads}
       />
       <main className="flex-1 overflow-y-auto p-6">
-        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-          {skills.map((skill) => (
-            <ModuleCard
-              key={skill.slug}
-              skill={skill}
-              weeklyDownloads={statsMap[skill.slug]?.weeklyDownloads ?? 0}
-            />
-          ))}
-        </div>
+        <SkillsGrid skills={skills} />
       </main>
     </div>
   )

--- a/apps/platform/components/DashboardAlt.tsx
+++ b/apps/platform/components/DashboardAlt.tsx
@@ -1,138 +1,30 @@
 "use client"
 
-import { useEffect, useState } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@thinkthroo/ui/components/card"
 import { Progress } from "@thinkthroo/ui/components/progress"
 import { Button } from "@thinkthroo/ui/components/button"
-import { courseProgressClient } from "@/service/courseProgress/client"
-import { BookOpen, Code2, PlayCircle, RotateCcw, Clock, Trophy } from "lucide-react"
+import { courseData, getCategoryProgress } from "@/lib/course-data"
+import { BookOpen, Code2, PlayCircle, Clock, Trophy } from "lucide-react"
 import Link from "next/link"
-import { Skeleton } from "@thinkthroo/ui/components/skeleton"
-
-// ── Types from the stats API ─────────────────────────────────────────
-
-interface ModuleStat {
-  slug: string
-  title: string
-  lessonCount: number
-  firstLessonHref: string
-}
-
-interface CourseStat {
-  courseSlug: string
-  title: string
-  modules: ModuleStat[]
-  totalLessons: number
-}
-
-// ── Static display config keyed by courseSlug ─────────────────────────
-
-const COURSE_CONFIG: Record<
-  string,
-  { icon: React.ElementType; href: string }
-> = {
-  architecture: { icon: Code2, href: "/architecture" },
-  "production-grade-projects": { icon: BookOpen, href: "/production-grade-projects" },
-}
-
-// ── Component ─────────────────────────────────────────────────────────
 
 export default function DashboardAltPage() {
-  const [loading, setLoading] = useState(true)
-  const [courses, setCourses] = useState<CourseStat[]>([])
-  const [completedSlugs, setCompletedSlugs] = useState<
-    { courseSlug: string; moduleSlug: string; lessonSlug: string }[]
-  >([])
-  const [enrollments, setEnrollments] = useState<
-    {
-      courseSlug: string
-      moduleSlug: string
-      lastChapterSlug: string | null
-      lastLessonSlug: string | null
-      lastAccessedAt: string
-    }[]
-  >([])
+  const totalLessons = courseData.reduce(
+    (acc, cat) =>
+      acc + cat.modules.reduce((mAcc, m) => mAcc + m.chapters.reduce((chAcc, ch) => chAcc + ch.lessons.length, 0), 0),
+    0,
+  )
 
-  useEffect(() => {
-    const load = async () => {
-      try {
-        const [statsRes, completed, enrolled] = await Promise.all([
-          fetch("/api/dashboard/stats").then((r) => r.json() as Promise<CourseStat[]>),
-          courseProgressClient.getCompletedLessons({}),
-          courseProgressClient.getAllEnrollments(),
-        ])
+  const completedLessons = courseData.reduce(
+    (acc, cat) =>
+      acc +
+      cat.modules.reduce(
+        (mAcc, m) => mAcc + m.chapters.reduce((chAcc, ch) => chAcc + ch.lessons.filter((l) => l.completed).length, 0),
+        0,
+      ),
+    0,
+  )
 
-        setCourses(statsRes)
-        setCompletedSlugs(
-          completed.map((r) => ({
-            courseSlug: r.courseSlug,
-            moduleSlug: r.moduleSlug,
-            lessonSlug: r.lessonSlug,
-          }))
-        )
-        setEnrollments(enrolled as typeof enrollments)
-      } finally {
-        setLoading(false)
-      }
-    }
-    load().catch(console.error)
-  }, [])
-
-  // ── Aggregates ───────────────────────────────────────────────────────
-
-  const totalLessons = courses.reduce((s, c) => s + c.totalLessons, 0)
-  const completedCount = completedSlugs.length
-  const overallProgress =
-    totalLessons > 0 ? Math.round((completedCount / totalLessons) * 100) : 0
-
-  // Per-course helpers
-  const completedForCourse = (courseSlug: string) =>
-    completedSlugs.filter((l) => l.courseSlug === courseSlug).length
-
-  const progressForCourse = (course: CourseStat) => {
-    const done = completedForCourse(course.courseSlug)
-    return course.totalLessons > 0
-      ? Math.round((done / course.totalLessons) * 100)
-      : 0
-  }
-
-  /** Find the most-recently-accessed enrollment for a course */
-  const latestEnrollment = (courseSlug: string) => {
-    const rows = enrollments
-      .filter((e) => e.courseSlug === courseSlug)
-      .sort(
-        (a, b) =>
-          new Date(b.lastAccessedAt).getTime() -
-          new Date(a.lastAccessedAt).getTime()
-      )
-    return rows[0] ?? null
-  }
-
-  const ctaForCourse = (
-    course: CourseStat
-  ): { label: string; href: string; Icon: React.ElementType } => {
-    const enrollment = latestEnrollment(course.courseSlug)
-    const done = completedForCourse(course.courseSlug)
-    const config = COURSE_CONFIG[course.courseSlug]
-    const fallbackHref = config?.href ?? `/${course.courseSlug}`
-
-    if (!enrollment) {
-      return { label: "Start Learning", href: fallbackHref, Icon: PlayCircle }
-    }
-
-    if (course.totalLessons > 0 && done >= course.totalLessons) {
-      return { label: "Restart", href: fallbackHref, Icon: RotateCcw }
-    }
-
-    const resumeHref =
-      enrollment.lastChapterSlug && enrollment.lastLessonSlug
-        ? `/${course.courseSlug}/${enrollment.moduleSlug}/${enrollment.lastChapterSlug}/${enrollment.lastLessonSlug}`
-        : fallbackHref
-
-    return { label: "Continue", href: resumeHref, Icon: PlayCircle }
-  }
-
-  // ── Render ────────────────────────────────────────────────────────────
+  const overallProgress = Math.round((completedLessons / totalLessons) * 100)
 
   return (
     <div className="space-y-8">
@@ -141,120 +33,91 @@ export default function DashboardAltPage() {
         <p className="text-muted-foreground mt-1">Continue your learning journey</p>
       </div>
 
-      {/* Stats row */}
       <div className="grid gap-4 md:grid-cols-4">
-        <Card>
-          <CardHeader className="pb-2">
-            <CardDescription>Overall Progress</CardDescription>
-            {loading ? (
-              <Skeleton className="h-9 w-16" />
-            ) : (
-              <CardTitle className="text-3xl">{overallProgress}%</CardTitle>
-            )}
-          </CardHeader>
-          <CardContent>
-            <Progress value={loading ? 0 : overallProgress} className="h-2" />
-          </CardContent>
-        </Card>
+              <Card>
+                <CardHeader className="pb-2">
+                  <CardDescription>Overall Progress</CardDescription>
+                  <CardTitle className="text-3xl">{overallProgress}%</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <Progress value={overallProgress} className="h-2" />
+                </CardContent>
+              </Card>
 
-        <Card>
-          <CardHeader className="pb-2">
-            <CardDescription>Lessons Completed</CardDescription>
-            {loading ? (
-              <Skeleton className="h-9 w-20" />
-            ) : (
-              <CardTitle className="text-3xl">
-                {completedCount}/{totalLessons}
-              </CardTitle>
-            )}
-          </CardHeader>
-          <CardContent className="flex items-center gap-2 text-muted-foreground">
-            <BookOpen className="h-4 w-4" />
-            <span className="text-sm">lessons</span>
-          </CardContent>
-        </Card>
+              <Card>
+                <CardHeader className="pb-2">
+                  <CardDescription>Lessons Completed</CardDescription>
+                  <CardTitle className="text-3xl">
+                    {completedLessons}/{totalLessons}
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="flex items-center gap-2 text-muted-foreground">
+                  <BookOpen className="h-4 w-4" />
+                  <span className="text-sm">lessons</span>
+                </CardContent>
+              </Card>
 
-        <Card>
-          <CardHeader className="pb-2">
-            <CardDescription>Time Invested</CardDescription>
-            <CardTitle className="text-3xl">—</CardTitle>
-          </CardHeader>
-          <CardContent className="flex items-center gap-2 text-muted-foreground">
-            <Clock className="h-4 w-4" />
-            <span className="text-sm">coming soon</span>
-          </CardContent>
-        </Card>
+              <Card>
+                <CardHeader className="pb-2">
+                  <CardDescription>Time Invested</CardDescription>
+                  <CardTitle className="text-3xl">2.5h</CardTitle>
+                </CardHeader>
+                <CardContent className="flex items-center gap-2 text-muted-foreground">
+                  <Clock className="h-4 w-4" />
+                  <span className="text-sm">this week</span>
+                </CardContent>
+              </Card>
 
-        <Card>
-          <CardHeader className="pb-2">
-            <CardDescription>Achievements</CardDescription>
-            <CardTitle className="text-3xl">—</CardTitle>
-          </CardHeader>
-          <CardContent className="flex items-center gap-2 text-muted-foreground">
-            <Trophy className="h-4 w-4" />
-            <span className="text-sm">coming soon</span>
-          </CardContent>
-        </Card>
+              <Card>
+                <CardHeader className="pb-2">
+                  <CardDescription>Achievements</CardDescription>
+                  <CardTitle className="text-3xl">3</CardTitle>
+                </CardHeader>
+                <CardContent className="flex items-center gap-2 text-muted-foreground">
+                  <Trophy className="h-4 w-4" />
+                  <span className="text-sm">badges earned</span>
+                </CardContent>
+              </Card>
       </div>
 
-      {/* Continue Learning */}
       <div>
         <h2 className="text-xl font-semibold mb-4">Continue Learning</h2>
         <div className="grid gap-4 md:grid-cols-2">
-          {loading
-            ? [0, 1].map((i) => (
-                <Card key={i}>
-                  <CardHeader>
-                    <Skeleton className="h-10 w-10 rounded-lg" />
-                    <Skeleton className="h-5 w-40 mt-2" />
-                    <Skeleton className="h-4 w-24 mt-1" />
-                  </CardHeader>
-                  <CardContent className="space-y-4">
-                    <Skeleton className="h-2 w-full" />
-                    <Skeleton className="h-10 w-full" />
-                  </CardContent>
-                </Card>
-              ))
-            : courses.map((course) => {
-                const progress = progressForCourse(course)
-                const cta = ctaForCourse(course)
-                const config = COURSE_CONFIG[course.courseSlug]
-                const Icon = config?.icon ?? BookOpen
+                {courseData.map((category) => {
+                  const progress = getCategoryProgress(category)
+                  const Icon = category.slug === "codebase-architecture" ? Code2 : BookOpen
 
-                return (
-                  <Card key={course.courseSlug} className="group hover:shadow-md transition-shadow">
-                    <CardHeader>
-                      <div className="flex items-center gap-3">
-                        <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
-                          <Icon className="h-5 w-5" />
+                  return (
+                    <Card key={category.id} className="group hover:shadow-md transition-shadow">
+                      <CardHeader>
+                        <div className="flex items-center gap-3">
+                          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                            <Icon className="h-5 w-5" />
+                          </div>
+                          <div className="flex-1">
+                            <CardTitle className="text-lg">{category.title}</CardTitle>
+                            <CardDescription>{category.modules.length} modules</CardDescription>
+                          </div>
                         </div>
-                        <div className="flex-1">
-                          <CardTitle className="text-lg">{course.title}</CardTitle>
-                          <CardDescription>
-                            {course.modules.length}{" "}
-                            {course.modules.length === 1 ? "module" : "modules"}
-                          </CardDescription>
+                      </CardHeader>
+                      <CardContent className="space-y-4">
+                        <div className="space-y-2">
+                          <div className="flex justify-between text-sm">
+                            <span className="text-muted-foreground">Progress</span>
+                            <span className="font-medium">{progress}%</span>
+                          </div>
+                          <Progress value={progress} className="h-2" />
                         </div>
-                      </div>
-                    </CardHeader>
-                    <CardContent className="space-y-4">
-                      <div className="space-y-2">
-                        <div className="flex justify-between text-sm">
-                          <span className="text-muted-foreground">Progress</span>
-                          <span className="font-medium">{progress}%</span>
-                        </div>
-                        <Progress value={progress} className="h-2" />
-                      </div>
-                      <Button asChild className="w-full">
-                        <Link href={cta.href}>
-                          <cta.Icon className="mr-2 h-4 w-4" />
-                          {cta.label}
-                        </Link>
-                      </Button>
-                    </CardContent>
-                  </Card>
-                )
-              })}
+                        <Button asChild className="w-full">
+                          <Link href={`/learn/${category.slug}`}>
+                            <PlayCircle className="mr-2 h-4 w-4" />
+                            {progress === 0 ? "Start Learning" : "Continue"}
+                          </Link>
+                        </Button>
+                      </CardContent>
+                    </Card>
+                  )
+                })}
         </div>
       </div>
     </div>

--- a/apps/platform/instrumentation.ts
+++ b/apps/platform/instrumentation.ts
@@ -1,26 +1,30 @@
-import { BatchLogRecordProcessor, LoggerProvider } from "@opentelemetry/sdk-logs";
-import { OTLPLogExporter } from "@opentelemetry/exporter-logs-otlp-http";
 import { logs } from "@opentelemetry/api-logs";
-import { resourceFromAttributes } from "@opentelemetry/resources";
 
-// Created outside register() so it can be exported and flushed in route handlers
-export const loggerProvider = new LoggerProvider({
-  resource: resourceFromAttributes({ "service.name": "thinkthroo-platform" }),
-  processors: [
-    new BatchLogRecordProcessor(
-      new OTLPLogExporter({
-        url: "https://us.i.posthog.com/i/v1/logs",
-        headers: {
-          Authorization: `Bearer ${process.env.NEXT_PUBLIC_POSTHOG_KEY}`,
-          "Content-Type": "application/json",
-        },
-      })
-    ),
-  ],
-});
+// Lazily created so the Node.js-only OpenTelemetry SDK is never evaluated
+// in the edge runtime (which causes "Cannot read properties of undefined").
+export let loggerProvider: import("@opentelemetry/sdk-logs").LoggerProvider | undefined
 
 export async function register() {
   if (process.env.NEXT_RUNTIME === "nodejs") {
+    const { BatchLogRecordProcessor, LoggerProvider } = await import("@opentelemetry/sdk-logs");
+    const { OTLPLogExporter } = await import("@opentelemetry/exporter-logs-otlp-http");
+    const { resourceFromAttributes } = await import("@opentelemetry/resources");
+
+    loggerProvider = new LoggerProvider({
+      resource: resourceFromAttributes({ "service.name": "thinkthroo-platform" }),
+      processors: [
+        new BatchLogRecordProcessor(
+          new OTLPLogExporter({
+            url: "https://us.i.posthog.com/i/v1/logs",
+            headers: {
+              Authorization: `Bearer ${process.env.NEXT_PUBLIC_POSTHOG_KEY}`,
+              "Content-Type": "application/json",
+            },
+          })
+        ),
+      ],
+    });
+
     logs.setGlobalLoggerProvider(loggerProvider);
   }
 }

--- a/apps/platform/lib/skill.ts
+++ b/apps/platform/lib/skill.ts
@@ -71,7 +71,7 @@ export async function fetchAllSkills(): Promise<SanitySkill[]> {
   return sanityClient.fetch<SanitySkill[]>(
     SKILLS_LIST_QUERY,
     {},
-    { next: { revalidate: 60 } }
+    { next: { revalidate: 0 } }
   );
 }
 


### PR DESCRIPTION
## Summary by Sourcery

Update analytics, dashboard, and skills-library experiences to focus on static learning metrics and tag-based skill discovery while hardening logging for edge runtimes.

New Features:
- Add a PR analytics view with static weekly pull request metrics, including merged PRs and review activity chart plus tabular breakdown.
- Introduce tag-based filtering for the skills library via a client-side skills grid component with a tag selector.
- Display learning progress and course summaries on the main dashboard using course data, mirroring the learn dashboard layout.

Bug Fixes:
- Prevent edge runtime crashes by avoiding eager import of Node-only OpenTelemetry logging SDKs in instrumentation.

Enhancements:
- Replace dynamic, organization-scoped analytics with a simplified static analytics page and updated loading skeletons.
- Simplify the learn dashboard by removing server-driven progress APIs in favor of local course-data-based progress computation.
- Refine skills module cards and category header to remove download statistics, adjust tags display, and show a fallback when no tags exist.
- Disable ISR revalidation for skills data to always fetch fresh skills from Sanity.
- Lazily initialize the OpenTelemetry logger provider only in the Node.js runtime to avoid edge runtime errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tag-based filtering for the Skills Library to easily browse skills by category.
  * Introduced a redesigned Dashboard displaying learning progress, completed lessons, and personalized course recommendations.

* **Improvements**
  * Simplified Analytics page with focused weekly metrics visualization and cleaner table layout.
  * Enhanced Skills Library card display with streamlined information presentation.
  * Optimized dashboard loading experience with improved data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->