### PR TITLE
enable toggle

### DIFF
--- a/apps/platform/app/(platform)/organization-settings/components/OrganizationSettingsTab.tsx
+++ b/apps/platform/app/(platform)/organization-settings/components/OrganizationSettingsTab.tsx
@@ -71,13 +71,20 @@ export function OrganizationSettingsTab() {
     setPathFilters((prev) => prev.filter((f) => f !== filter))
   }
 
+  const handleEnableReviewsChange = (checked: boolean) => {
+    setEnableReviews(checked)
+    if (!checked) {
+      setEnablePrSummary(false)
+    }
+  }
+
   const handleSave = async () => {
     if (!activeOrg?.id) return
     setIsSaving(true)
     try {
       await organizationSettingsClientService.upsert(activeOrg.id, {
           enableReviews,
-          enablePrSummary,
+          enablePrSummary: enableReviews ? enablePrSummary : false,
           enableInlineReviewComments: isPro ? enableInlineReviewComments : false,
           enableArchitectureReview: isPro ? enableArchitectureReview : false,
           reviewLanguage: language || null,
@@ -112,7 +119,7 @@ export function OrganizationSettingsTab() {
           <div className="flex items-center">
             <Switch
               checked={enableReviews}
-              onCheckedChange={setEnableReviews}
+              onCheckedChange={handleEnableReviewsChange}
               className="data-[state=checked]:bg-black data-[state=unchecked]:bg-gray-200"
             />
           </div>
@@ -132,6 +139,7 @@ export function OrganizationSettingsTab() {
             <Switch
               checked={enablePrSummary}
               onCheckedChange={setEnablePrSummary}
+              disabled={!enableReviews}
               className="data-[state=checked]:bg-black data-[state=unchecked]:bg-gray-200"
             />
           </div>

--- a/apps/platform/app/(platform)/repositories/[repository]/settings/components/SettingsTab.tsx
+++ b/apps/platform/app/(platform)/repositories/[repository]/settings/components/SettingsTab.tsx
@@ -83,6 +83,13 @@ export function SettingsTab() {
     setPathFilters((prev) => prev.filter((f) => f !== filter))
   }
 
+  const handleEnableReviewsChange = (checked: boolean) => {
+    setEnableReviews(checked)
+    if (!checked) {
+      setEnablePrSummary(false)
+    }
+  }
+
   const handleSave = async () => {
     if (!repositoryId || !organizationId) return
     setIsSaving(true)
@@ -90,7 +97,7 @@ export function SettingsTab() {
       await repositorySettingsClientService.upsert(repositoryId, organizationId, {
           useOrganizationSettings: useOrgSettings,
           enableReviews,
-          enablePrSummary,
+          enablePrSummary: enableReviews ? enablePrSummary : false,
           enableInlineReviewComments: isPro ? enableInlineReviewComments : false,
           enableArchitectureReview: isPro ? enableArchitectureReview : false,
           reviewLanguage: language || null,
@@ -146,7 +153,7 @@ export function SettingsTab() {
           <div className="flex items-center">
             <Switch
               checked={enableReviews}
-              onCheckedChange={setEnableReviews}
+              onCheckedChange={handleEnableReviewsChange}
               disabled={disabled}
               className="data-[state=checked]:bg-black data-[state=unchecked]:bg-gray-200"
             />
@@ -167,7 +174,7 @@ export function SettingsTab() {
             <Switch
               checked={enablePrSummary}
               onCheckedChange={setEnablePrSummary}
-              disabled={disabled}
+              disabled={disabled || !enableReviews}
               className="data-[state=checked]:bg-black data-[state=unchecked]:bg-gray-200"
             />
           </div>


### PR DESCRIPTION
## Summary by Sourcery

Ensure PR summary settings are only enabled and saved when reviews are enabled at both repository and organization levels.

New Features:
- Disable PR summary toggles when reviews are turned off in repository and organization settings.

Bug Fixes:
- Prevent saving PR summary as enabled when reviews are disabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced dependency between Enable Reviews and Enable PR Summary settings. When reviews are disabled, PR summary is automatically turned off and its toggle becomes unavailable to prevent inconsistent configuration states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramu-narasinga/thinkthroo/pull/296)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->