### PR TITLE
posthog logs init

### DIFF
--- a/apps/github-app/api/process-review.ts
+++ b/apps/github-app/api/process-review.ts
@@ -1,10 +1,15 @@
 import { qstashConsumerHandler } from "../lib/features/pr-workflow/QStashConsumerHandler";
+import { initPostHogLogs } from "../lib/utils/posthog-logs";
+import { logger } from "../lib/utils/logger";
 import type { VercelRequest, VercelResponse } from "@vercel/node";
+
+initPostHogLogs();
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== "POST") {
     res.status(405).json({ error: "Method not allowed" });
     return;
   }
+  logger.info("QStash consumer endpoint hit", { method: req.method });
   await qstashConsumerHandler(req as any, res as any);
 }

--- a/apps/github-app/vercel.json
+++ b/apps/github-app/vercel.json
@@ -1,4 +1,5 @@
 {
+  "buildCommand": "npm run build",
   "functions": {
     "api/process-review.ts": {
       "maxDuration": 300


### PR DESCRIPTION
## Summary by Sourcery

Initialize PostHog logging for the GitHub app review processing endpoint and add basic request logging for QStash consumer invocations.

Enhancements:
- Set up PostHog logs initialization in the GitHub app process-review API handler.
- Log incoming QStash consumer requests with HTTP method metadata for observability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Enhanced logging infrastructure for improved monitoring and diagnostics.
* Updated build configuration to ensure consistent deployment process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->