### PR TITLE
fix(github-app): thread contextual logger through all PR workflow ser…

### DIFF
--- a/apps/github-app/src/features/architecture-review/ArchitectureReviewGenerator.ts
+++ b/apps/github-app/src/features/architecture-review/ArchitectureReviewGenerator.ts
@@ -65,12 +65,12 @@ export class ArchitectureReviewGenerator {
     };
 
     const issueDetails = context.issue();
-    this.preprocessor = new PRPreprocessor(context.octokit, issueDetails);
-    this.commentManager = new CommentManager(context.octokit, issueDetails);
+    this.preprocessor = new PRPreprocessor(context.octokit, issueDetails, this.log);
+    this.commentManager = new CommentManager(context.octokit, issueDetails, this.log);
 
     const aiOptions = getDefaultAIOptions();
     this.reviewBot = new ClaudeBot(aiOptions.reviewBot, undefined, this.log);
-    this.prompts = new Prompts();
+    this.prompts = new Prompts(undefined, undefined, this.log);
     this.architectureService = new ArchitectureService();
     this.reviewParser = new ReviewParser();
 

--- a/apps/github-app/src/features/generate-pr-review/PullRequestReviewGenerator.ts
+++ b/apps/github-app/src/features/generate-pr-review/PullRequestReviewGenerator.ts
@@ -71,7 +71,7 @@ export class PullRequestReviewGenerator {
       repo: issueDetails.repo,
     });
 
-    this.preprocessor = new PRPreprocessor(octokit, issueDetails);
+    this.preprocessor = new PRPreprocessor(octokit, issueDetails, this.log);
     this.fileReviewFilter = new FileReviewFilter();
 
     this.aiOptions = getDefaultAIOptions();
@@ -99,7 +99,7 @@ export class PullRequestReviewGenerator {
       throw e;
     }
 
-    this.prompts = new Prompts();
+    this.prompts = new Prompts(undefined, undefined, this.log);
 
     this.log.info("PullRequestReviewGenerator initialized successfully", {
       prNumber,

--- a/apps/github-app/src/features/generate-pr-summary/PullRequestSummaryGenerator.ts
+++ b/apps/github-app/src/features/generate-pr-summary/PullRequestSummaryGenerator.ts
@@ -35,9 +35,9 @@ export class PullRequestSummaryGenerator {
     const issueDetails = context.issue();
     const octokit = context.octokit;
 
-    this.commentManager = new CommentManager(octokit, issueDetails);
-    this.commitAnalyzer = new CommitAnalyzer(octokit, issueDetails);
-    this.preprocessor = new PRPreprocessor(octokit, issueDetails);
+    this.commentManager = new CommentManager(octokit, issueDetails, this.log);
+    this.commitAnalyzer = new CommitAnalyzer(octokit, issueDetails, this.log);
+    this.preprocessor = new PRPreprocessor(octokit, issueDetails, this.log);
 
     this.aiOptions = getDefaultAIOptions();
 
@@ -64,7 +64,7 @@ export class PullRequestSummaryGenerator {
     }
 
     // Initialize prompts
-    this.prompts = new Prompts();
+    this.prompts = new Prompts(undefined, undefined, this.log);
 
     // Initialize file summarizer with DI
     this.fileSummarizer = new FileSummarizer(

--- a/apps/github-app/src/features/pr-workflow/PRWorkflowOrchestrator.ts
+++ b/apps/github-app/src/features/pr-workflow/PRWorkflowOrchestrator.ts
@@ -176,8 +176,8 @@ export class PRWorkflowOrchestrator {
     let _existingComment: any | null = null;
 
     try {
-      const commitAnalyzer = new CommitAnalyzer(octokit, issueDetails);
-      const commentManager = new CommentManager(octokit, issueDetails);
+      const commitAnalyzer = new CommitAnalyzer(octokit, issueDetails, prLogger);
+      const commentManager = new CommentManager(octokit, issueDetails, prLogger);
       _commitAnalyzer = commitAnalyzer;
       _commentManager = commentManager;
       const existingCommentData = await commentManager.getExistingCommentData(

--- a/apps/github-app/src/services/ai/Prompts.ts
+++ b/apps/github-app/src/services/ai/Prompts.ts
@@ -17,7 +17,7 @@ export interface TemplateData {
   [key: string]: string | undefined;
 }
 
-import { logger } from "@/utils/logger";
+import { logger, type Logger } from "@/utils/logger";
 
 /**
  * Prompts service for PR review and summarization
@@ -354,6 +354,8 @@ $comment
 \`\`\`
 `;
 
+  private readonly log: Logger;
+
   constructor(
     summarize = `Your task is to produce a concise, categorized summary of the PR changes.
 
@@ -394,17 +396,19 @@ Output format:
 
 **<Category>:**
 - <change>
-`
+`,
+    log?: Logger
   ) {
     this.summarize = summarize;
     this.summarizeReleaseNotes = summarizeReleaseNotes;
+    this.log = log ?? logger;
   }
 
   /**
    * Render a template string with data
    */
   private render(template: string, data: TemplateData): string {
-    logger.debug("Rendering prompt template", {
+    this.log.debug("Rendering prompt template", {
       templateLength: template.length,
       dataKeys: Object.keys(data),
       hasTitle: !!data.title,
@@ -436,7 +440,7 @@ Output format:
       }
     }
 
-    logger.debug("Prompt template rendered", {
+    this.log.debug("Prompt template rendered", {
       originalLength: template.length,
       renderedLength: result.length,
       replacementsMade: Object.keys(replacements).length,
@@ -450,7 +454,7 @@ Output format:
     data: TemplateData,
     reviewSimpleChanges: boolean
   ): string {
-    logger.debug("Rendering summarize file diff prompt", {
+    this.log.debug("Rendering summarize file diff prompt", {
       filename: data.filename,
       reviewSimpleChanges,
       hasFileDiff: !!(data.file_diff || data.fileDiff),
@@ -470,7 +474,7 @@ Output format:
     
     const result = this.render(prompt, normalizedData);
     
-    logger.info("Summarize file diff prompt rendered", {
+    this.log.info("Summarize file diff prompt rendered", {
       filename: data.filename,
       includesTriage: reviewSimpleChanges === false,
       promptLength: result.length,
@@ -480,14 +484,14 @@ Output format:
   }
 
   renderSummarizeChangesets(data: TemplateData): string {
-    logger.debug("Rendering summarize changesets prompt", {
+    this.log.debug("Rendering summarize changesets prompt", {
       hasRawSummary: !!data.raw_summary,
       rawSummaryLength: data.raw_summary?.length || 0,
     });
 
     const result = this.render(this.summarizeChangesets, data);
     
-    logger.info("Summarize changesets prompt rendered", {
+    this.log.info("Summarize changesets prompt rendered", {
       promptLength: result.length,
       inputSummaryLength: data.raw_summary?.length || 0,
     });
@@ -496,7 +500,7 @@ Output format:
   }
 
   renderSummarize(data: TemplateData): string {
-    logger.debug("Rendering summarize prompt", {
+    this.log.debug("Rendering summarize prompt", {
       hasRawSummary: !!data.raw_summary,
       rawSummaryLength: data.raw_summary?.length || 0,
     });
@@ -504,7 +508,7 @@ Output format:
     const prompt = this.summarizePrefix + this.summarize;
     const result = this.render(prompt, data);
     
-    logger.info("Summarize prompt rendered", {
+    this.log.info("Summarize prompt rendered", {
       promptLength: result.length,
       inputSummaryLength: data.raw_summary?.length || 0,
     });
@@ -513,7 +517,7 @@ Output format:
   }
 
   renderSummarizeShort(data: TemplateData): string {
-    logger.debug("Rendering summarize short prompt", {
+    this.log.debug("Rendering summarize short prompt", {
       hasRawSummary: !!data.raw_summary,
       rawSummaryLength: data.raw_summary?.length || 0,
     });
@@ -521,7 +525,7 @@ Output format:
     const prompt = this.summarizePrefix + this.summarizeShort;
     const result = this.render(prompt, data);
     
-    logger.info("Summarize short prompt rendered", {
+    this.log.info("Summarize short prompt rendered", {
       promptLength: result.length,
       inputSummaryLength: data.raw_summary?.length || 0,
     });
@@ -530,7 +534,7 @@ Output format:
   }
 
   renderSummarizeReleaseNotes(data: TemplateData): string {
-    logger.debug("Rendering summarize release notes prompt", {
+    this.log.debug("Rendering summarize release notes prompt", {
       hasRawSummary: !!data.raw_summary,
       rawSummaryLength: data.raw_summary?.length || 0,
     });
@@ -538,7 +542,7 @@ Output format:
     const prompt = this.summarizePrefix + this.summarizeReleaseNotes;
     const result = this.render(prompt, data);
     
-    logger.info("Summarize release notes prompt rendered", {
+    this.log.info("Summarize release notes prompt rendered", {
       promptLength: result.length,
       inputSummaryLength: data.raw_summary?.length || 0,
     });

--- a/apps/github-app/src/services/comments/CommentManager.ts
+++ b/apps/github-app/src/services/comments/CommentManager.ts
@@ -14,7 +14,7 @@ import {
   REVIEW_PAUSED_NOTICE_TAG,
   REVIEW_PAUSED_TAG,
 } from "@/services/constants";
-import { logger } from "@/utils/logger";
+import { logger, type Logger } from "@/utils/logger";
 
 export interface ExistingCommentData {
   comment: any | null;
@@ -31,24 +31,27 @@ const issueCommentsCache: Record<number, any[]> = {};
  */
 export class CommentManager {
   private readonly botLogin: string | undefined;
+  private readonly log: Logger;
 
   constructor(
     private readonly octokit: Context["octokit"],
-    private readonly issueDetails: IssueDetails
+    private readonly issueDetails: IssueDetails,
+    log?: Logger
   ) {
     this.botLogin = process.env.GITHUB_BOT_LOGIN;
+    this.log = log ?? logger;
   }
 
   private async listComments(issueNumber: number): Promise<any[]> {
     if (issueCommentsCache[issueNumber]) {
-      logger.debug("Using cached comments", { 
+      this.log.debug("Using cached comments", { 
         issueNumber,
         cachedCount: issueCommentsCache[issueNumber].length 
       });
       return issueCommentsCache[issueNumber];
     }
 
-    logger.info("Fetching comments from GitHub API", { 
+    this.log.info("Fetching comments from GitHub API", { 
       issueNumber,
       owner: this.issueDetails.owner,
       repo: this.issueDetails.repo 
@@ -58,7 +61,7 @@ export class CommentManager {
     let page = 1;
     try {
       for (;;) {
-        logger.debug("Fetching comments page", { 
+        this.log.debug("Fetching comments page", { 
           issueNumber, 
           page, 
           perPage: 100 
@@ -73,7 +76,7 @@ export class CommentManager {
         });
         
         allComments.push(...comments);
-        logger.debug("Comments page fetched", { 
+        this.log.debug("Comments page fetched", { 
           issueNumber, 
           page, 
           commentsInPage: comments.length,
@@ -87,14 +90,14 @@ export class CommentManager {
       }
 
       issueCommentsCache[issueNumber] = allComments;
-      logger.info("All comments fetched and cached", { 
+      this.log.info("All comments fetched and cached", { 
         issueNumber, 
         totalComments: allComments.length,
         totalPages: page - 1 
       });
       return allComments;
     } catch (e: any) {
-      logger.error("Failed to list comments", {
+      this.log.error("Failed to list comments", {
         issueNumber,
         page,
         partialCount: allComments.length,
@@ -109,7 +112,7 @@ export class CommentManager {
     tag: string,
     comments: any[]
   ): Promise<any | null> {
-    logger.debug("Searching for comment with tag", { 
+    this.log.debug("Searching for comment with tag", { 
       tag, 
       totalComments: comments.length 
     });
@@ -118,7 +121,7 @@ export class CommentManager {
       for (const cmt of comments) {
         if (cmt.body && cmt.body.includes(tag)) {
           if (this.botLogin && cmt.user?.login !== this.botLogin) {
-            logger.debug("Skipping comment with tag: author mismatch", {
+            this.log.debug("Skipping comment with tag: author mismatch", {
               tag,
               commentId: cmt.id,
               commentAuthor: cmt.user?.login,
@@ -126,7 +129,7 @@ export class CommentManager {
             });
             continue;
           }
-          logger.info("Comment with tag found", { 
+          this.log.info("Comment with tag found", { 
             tag, 
             commentId: cmt.id,
             commentAuthor: cmt.user?.login,
@@ -138,13 +141,13 @@ export class CommentManager {
         }
       }
       
-      logger.debug("No comment found with tag", { 
+      this.log.debug("No comment found with tag", { 
         tag, 
         searchedComments: comments.length 
       });
       return null;
     } catch (e: unknown) {
-      logger.error("Error while searching for comment with tag", { 
+      this.log.error("Error while searching for comment with tag", { 
         tag, 
         error: String(e),
         totalComments: comments.length 
@@ -163,7 +166,7 @@ export class CommentManager {
     
     if (start >= 0 && end >= 0) {
       const extracted = content.slice(start + startTag.length, end);
-      logger.debug("Content extracted within tags", { 
+      this.log.debug("Content extracted within tags", { 
         startTag: startTag.substring(0, 50),
         endTag: endTag.substring(0, 50),
         startIndex: start,
@@ -173,7 +176,7 @@ export class CommentManager {
       return extracted;
     }
     
-    logger.debug("Tags not found in content", { 
+    this.log.debug("Tags not found in content", { 
       startTag: startTag.substring(0, 50),
       endTag: endTag.substring(0, 50),
       startFound: start >= 0,
@@ -184,7 +187,7 @@ export class CommentManager {
   }
 
   private getRawSummary(summary: string): string {
-    logger.debug("Extracting raw summary", { 
+    this.log.debug("Extracting raw summary", { 
       summaryLength: summary.length 
     });
     
@@ -195,11 +198,11 @@ export class CommentManager {
     );
     
     if (result) {
-      logger.debug("Raw summary extracted", { 
+      this.log.debug("Raw summary extracted", { 
         rawSummaryLength: result.length 
       });
     } else {
-      logger.warn("Raw summary not found in comment", { 
+      this.log.warn("Raw summary not found in comment", { 
         summaryLength: summary.length 
       });
     }
@@ -208,7 +211,7 @@ export class CommentManager {
   }
 
   private getShortSummary(summary: string): string {
-    logger.debug("Extracting short summary", { 
+    this.log.debug("Extracting short summary", { 
       summaryLength: summary.length 
     });
     
@@ -219,11 +222,11 @@ export class CommentManager {
     );
     
     if (result) {
-      logger.debug("Short summary extracted", { 
+      this.log.debug("Short summary extracted", { 
         shortSummaryLength: result.length 
       });
     } else {
-      logger.warn("Short summary not found in comment", { 
+      this.log.warn("Short summary not found in comment", { 
         summaryLength: summary.length 
       });
     }
@@ -236,7 +239,7 @@ export class CommentManager {
     tag: string,
     getReviewedCommitIdsBlock: (commentBody: string) => string
   ): Promise<ExistingCommentData> {
-    logger.info("Fetching existing comment data", { 
+    this.log.info("Fetching existing comment data", { 
       pullNumber, 
       tag,
       owner: this.issueDetails.owner,
@@ -244,7 +247,7 @@ export class CommentManager {
     });
 
     const comments = await this.listComments(pullNumber);
-    logger.debug("Comments retrieved", { 
+    this.log.debug("Comments retrieved", { 
       pullNumber, 
       totalComments: comments.length 
     });
@@ -252,7 +255,7 @@ export class CommentManager {
     const existingComment = await this.findCommentWithTag(tag, comments);
 
     if (!existingComment) {
-      logger.info("No existing comment found with tag", { 
+      this.log.info("No existing comment found with tag", { 
         pullNumber, 
         tag 
       });
@@ -265,7 +268,7 @@ export class CommentManager {
       };
     }
 
-    logger.info("Existing comment found", { 
+    this.log.info("Existing comment found", { 
       pullNumber, 
       tag,
       commentId: existingComment.id,
@@ -277,7 +280,7 @@ export class CommentManager {
     const rawSummary = this.getRawSummary(commentBody);
     const shortSummary = this.getShortSummary(commentBody);
 
-    logger.debug("Extracted comment data", { 
+    this.log.debug("Extracted comment data", { 
       pullNumber,
       hasCommitIdsBlock: commitIdsBlock.length > 0,
       hasRawSummary: rawSummary.length > 0,
@@ -314,7 +317,7 @@ export class CommentManager {
     filesAndChanges: Array<[string, string, string, Array<[number, number, string]>]>,
     filterIgnoredFiles: any[]
   ): string {
-    logger.debug("Generating status message", {
+    this.log.debug("Generating status message", {
       reviewStartCommit,
       headSha,
       filesAndChangesCount: filesAndChanges.length,
@@ -324,7 +327,7 @@ export class CommentManager {
     // Calculate total patches across all files
     const totalPatches = filesAndChanges.reduce((sum, [, , , patches]) => sum + patches.length, 0);
 
-    logger.debug("Status message file details", {
+    this.log.debug("Status message file details", {
       selectedFiles: filesAndChanges.map(([filename, , , patches]) => ({
         filename,
         patchCount: patches.length,
@@ -364,7 +367,7 @@ ${
 }
 `;
 
-    logger.info("Status message generated", {
+    this.log.info("Status message generated", {
       reviewStartCommit,
       headSha,
       messageLength: statusMessage.length,
@@ -379,7 +382,7 @@ ${
   }
 
   addInProgressStatus(commentBody: string, statusMsg: string): string {
-    logger.debug("Adding in-progress status", {
+    this.log.debug("Adding in-progress status", {
       hasExistingComment: commentBody.length > 0,
       commentBodyLength: commentBody.length,
       statusMsgLength: statusMsg.length,
@@ -403,7 +406,7 @@ ${IN_PROGRESS_END_TAG}
 
 ${commentBody}`;
       
-      logger.info("In-progress status added to comment", {
+      this.log.info("In-progress status added to comment", {
         hadExistingMarker: false,
         originalLength: commentBody.length,
         newLength: result.length,
@@ -412,7 +415,7 @@ ${commentBody}`;
       return result;
     }
     
-    logger.debug("In-progress marker already exists in comment", {
+    this.log.debug("In-progress marker already exists in comment", {
       startIndex: start,
       endIndex: end,
       commentBodyLength: commentBody.length,
@@ -422,7 +425,7 @@ ${commentBody}`;
   }
 
   private async create(body: string, target: number): Promise<void> {
-    logger.debug("Creating new comment", {
+    this.log.debug("Creating new comment", {
       target,
       bodyLength: body.length,
       owner: this.issueDetails.owner,
@@ -445,14 +448,14 @@ ${commentBody}`;
         issueCommentsCache[target] = [response.data];
       }
       
-      logger.info("Comment created successfully", {
+      this.log.info("Comment created successfully", {
         target,
         commentId: response.data.id,
         commentUrl: response.data.html_url,
         bodyLength: body.length,
       });
     } catch (e: any) {
-      logger.error("Failed to create comment", {
+      this.log.error("Failed to create comment", {
         target,
         bodyLength: body.length,
         error: e.message,
@@ -462,7 +465,7 @@ ${commentBody}`;
   }
 
   private async replace(body: string, tag: string, target: number): Promise<void> {
-    logger.debug("Replacing comment with tag", {
+    this.log.debug("Replacing comment with tag", {
       target,
       tag,
       bodyLength: body.length,
@@ -475,7 +478,7 @@ ${commentBody}`;
       const cmt = await this.findCommentWithTag(tag, comments);
       
       if (cmt) {
-        logger.debug("Updating existing comment", {
+        this.log.debug("Updating existing comment", {
           target,
           tag,
           commentId: cmt.id,
@@ -499,21 +502,21 @@ ${commentBody}`;
           }
         }
         
-        logger.info("Comment updated successfully", {
+        this.log.info("Comment updated successfully", {
           target,
           tag,
           commentId: cmt.id,
           bodyLength: body.length,
         });
       } else {
-        logger.debug("No existing comment found, creating new one", {
+        this.log.debug("No existing comment found, creating new one", {
           target,
           tag,
         });
         await this.create(body, target);
       }
     } catch (e: any) {
-      logger.error("Failed to replace comment", {
+      this.log.error("Failed to replace comment", {
         target,
         tag,
         bodyLength: body.length,
@@ -529,7 +532,7 @@ ${commentBody}`;
   async comment(message: string, tag: string, mode: string = "replace"): Promise<void> {
     const finalTag = tag || COMMENT_TAG;
 
-    logger.debug("Preparing to post comment", {
+    this.log.debug("Preparing to post comment", {
       mode,
       tag: finalTag,
       messageLength: message.length,
@@ -540,7 +543,7 @@ ${commentBody}`;
 
 ${finalTag}`;
 
-    logger.debug("Comment body prepared", {
+    this.log.debug("Comment body prepared", {
       mode,
       tag: finalTag,
       bodyLength: body.length,
@@ -548,19 +551,19 @@ ${finalTag}`;
     });
 
     if (mode === "create") {
-      logger.info("Creating new comment", {
+      this.log.info("Creating new comment", {
         tag: finalTag,
         issueNumber: this.issueDetails.issue_number,
       });
       await this.create(body, this.issueDetails.issue_number);
     } else if (mode === "replace") {
-      logger.info("Replacing existing comment", {
+      this.log.info("Replacing existing comment", {
         tag: finalTag,
         issueNumber: this.issueDetails.issue_number,
       });
       await this.replace(body, finalTag, this.issueDetails.issue_number);
     } else {
-      logger.warn("Unknown comment mode, using replace", { 
+      this.log.warn("Unknown comment mode, using replace", { 
         mode,
         tag: finalTag,
         issueNumber: this.issueDetails.issue_number,
@@ -568,7 +571,7 @@ ${finalTag}`;
       await this.replace(body, finalTag, this.issueDetails.issue_number);
     }
 
-    logger.info("Comment operation completed", {
+    this.log.info("Comment operation completed", {
       mode,
       tag: finalTag,
       issueNumber: this.issueDetails.issue_number,
@@ -608,7 +611,7 @@ ${finalTag}`;
         body,
       });
     } catch (e: any) {
-      logger.warn("Failed to update PR description", {
+      this.log.warn("Failed to update PR description", {
         pullNumber,
         error: e.message,
       });
@@ -625,7 +628,7 @@ ${finalTag}`;
     shortSummary: string,
     commitIds: string[] = []
   ): string {
-    logger.debug("Building base summary comment", {
+    this.log.debug("Building base summary comment", {
       finalResponseLength: finalResponse.length,
       rawSummaryLength: rawSummary.length,
       shortSummaryLength: shortSummary.length,
@@ -669,7 +672,7 @@ If you like this project, please support us by starring the repository. This too
     let finalStatusMsg = baseStatusMsg;
     
     if (skippedFiles.length > 0) {
-      logger.debug("Adding skipped files to status message", {
+      this.log.debug("Adding skipped files to status message", {
         skippedFilesCount: skippedFiles.length,
       });
       finalStatusMsg += `\n<details>
@@ -682,7 +685,7 @@ If you like this project, please support us by starring the repository. This too
     }
 
     if (failedSummaries.length > 0) {
-      logger.debug("Adding failed summaries to status message", {
+      this.log.debug("Adding failed summaries to status message", {
         failedSummariesCount: failedSummaries.length,
       });
       finalStatusMsg += `\n<details>
@@ -694,7 +697,7 @@ If you like this project, please support us by starring the repository. This too
 `;
     }
 
-    logger.debug("Status message with errors built", {
+    this.log.debug("Status message with errors built", {
       hasSkippedFiles: skippedFiles.length > 0,
       hasFailedSummaries: failedSummaries.length > 0,
       finalLength: finalStatusMsg.length,
@@ -715,7 +718,7 @@ If you like this project, please support us by starring the repository. This too
     failedSummaries: string[],
     commitIds: string[] = []
   ): string {
-    logger.debug("Building final summary comment", {
+    this.log.debug("Building final summary comment", {
       hasSkippedFiles: skippedFiles.length > 0,
       hasFailedSummaries: failedSummaries.length > 0,
     });
@@ -735,7 +738,7 @@ If you like this project, please support us by starring the repository. This too
     
     const finalComment = `${statusMsg}\n\n${baseSummary}`;
     
-    logger.info("Final summary comment built", {
+    this.log.info("Final summary comment built", {
       totalLength: finalComment.length,
       statusMsgLength: statusMsg.length,
       baseSummaryLength: baseSummary.length,

--- a/apps/github-app/src/services/commits/CommitAnalyzer.ts
+++ b/apps/github-app/src/services/commits/CommitAnalyzer.ts
@@ -1,19 +1,24 @@
 import type { Context } from "probot";
 import type { IssueDetails } from "@/types/issue";
 import { COMMIT_ID_END_TAG, COMMIT_ID_START_TAG, REVIEW_EPOCH_BASE_TAG_PREFIX } from "@/services/constants";
-import { logger } from "@/utils/logger";
+import { logger, type Logger } from "@/utils/logger";
 
 /**
  * Analyzes commits to determine what needs to be reviewed
  */
 export class CommitAnalyzer {
+  private readonly log: Logger;
+
   constructor(
     private readonly octokit: Context["octokit"],
-    private readonly issueDetails: IssueDetails
-  ) {}
+    private readonly issueDetails: IssueDetails,
+    log?: Logger
+  ) {
+    this.log = log ?? logger;
+  }
 
   async getAllCommitIds(pullNumber: number): Promise<string[]> {
-    logger.debug("Fetching all commit IDs", { 
+    this.log.debug("Fetching all commit IDs", { 
       pullNumber, 
       owner: this.issueDetails.owner, 
       repo: this.issueDetails.repo 
@@ -24,7 +29,7 @@ export class CommitAnalyzer {
     let commits;
 
     do {
-      logger.debug("Fetching commits page", { pullNumber, page });
+      this.log.debug("Fetching commits page", { pullNumber, page });
       
       commits = await this.octokit.pulls.listCommits({
         owner: this.issueDetails.owner,
@@ -35,7 +40,7 @@ export class CommitAnalyzer {
       });
 
       allCommits.push(...commits.data.map((commit) => commit.sha));
-      logger.debug("Fetched commits from page", { 
+      this.log.debug("Fetched commits from page", { 
         pullNumber, 
         page, 
         commitsInPage: commits.data.length,
@@ -45,7 +50,7 @@ export class CommitAnalyzer {
       page++;
     } while (commits.data.length > 0);
 
-    logger.info("Successfully fetched all commit IDs", { 
+    this.log.info("Successfully fetched all commit IDs", { 
       pullNumber, 
       totalCommits: allCommits.length,
       commitIds: allCommits
@@ -98,7 +103,7 @@ export class CommitAnalyzer {
     baseSha: string,
     headSha: string
   ): string {
-    logger.debug("Determining review start commit", {
+    this.log.debug("Determining review start commit", {
       totalCommits: allCommitIds.length,
       hasExistingCommitBlock: existingCommitIdsBlock !== "",
       baseSha,
@@ -106,7 +111,7 @@ export class CommitAnalyzer {
     });
     
     if (existingCommitIdsBlock === "") {
-      logger.info("No existing review found - will review from base commit", { 
+      this.log.info("No existing review found - will review from base commit", { 
         baseSha,
         reason: "no existing commit block" 
       });
@@ -114,7 +119,7 @@ export class CommitAnalyzer {
     }
 
     const reviewedCommitIds = this.getReviewedCommitIds(existingCommitIdsBlock);
-    logger.debug("Retrieved previously reviewed commits", { 
+    this.log.debug("Retrieved previously reviewed commits", { 
       reviewedCommitCount: reviewedCommitIds.length,
       reviewedCommitIds 
     });
@@ -124,12 +129,12 @@ export class CommitAnalyzer {
       reviewedCommitIds
     );
     
-    logger.debug("Found highest reviewed commit", { 
+    this.log.debug("Found highest reviewed commit", { 
       highestReviewedCommitId: highestReviewedCommitId || "none"
     });
 
     if (highestReviewedCommitId === "" || highestReviewedCommitId === headSha) {
-      logger.info("Will review from base commit", { 
+      this.log.info("Will review from base commit", { 
         baseSha,
         reason: highestReviewedCommitId === "" ? "no matching reviewed commit found" : "highest reviewed commit matches head",
         highestReviewedCommitId: highestReviewedCommitId || "none",
@@ -138,7 +143,7 @@ export class CommitAnalyzer {
       return baseSha;
     }
 
-    logger.info("Will review from highest reviewed commit - incremental review", { 
+    this.log.info("Will review from highest reviewed commit - incremental review", { 
       highestReviewedCommitId,
       reviewedCommitCount: reviewedCommitIds.length,
       newCommitsToReview: allCommitIds.indexOf(highestReviewedCommitId) >= 0 

--- a/apps/github-app/src/services/diffs/DiffFetcher.ts
+++ b/apps/github-app/src/services/diffs/DiffFetcher.ts
@@ -1,6 +1,6 @@
 import type { Context } from "probot";
 import type { IssueDetails } from "@/types/issue";
-import { logger } from "@/utils/logger";
+import { logger, type Logger } from "@/utils/logger";
 
 export interface DiffData {
   files: any[];
@@ -11,11 +11,15 @@ export interface DiffData {
  * Fetches and compares diffs between commits
  */
 export class DiffFetcher {
+  private readonly log: Logger;
+
   constructor(
     private readonly octokit: Context["octokit"],
-    private readonly issueDetails: IssueDetails
+    private readonly issueDetails: IssueDetails,
+    log?: Logger
   ) {
-    logger.debug("DiffFetcher initialized", {
+    this.log = log ?? logger;
+    this.log.debug("DiffFetcher initialized", {
       owner: issueDetails.owner,
       repo: issueDetails.repo,
     });
@@ -25,7 +29,7 @@ export class DiffFetcher {
     baseSha: string,
     headSha: string
   ): Promise<DiffData> {
-    logger.debug("Fetching incremental diff", {
+    this.log.debug("Fetching incremental diff", {
       baseSha,
       headSha,
       owner: this.issueDetails.owner,
@@ -45,7 +49,7 @@ export class DiffFetcher {
         commits: diff.data.commits || [],
       };
 
-      logger.info("Incremental diff fetched successfully", {
+      this.log.info("Incremental diff fetched successfully", {
         baseSha,
         headSha,
         filesCount: result.files.length,
@@ -57,7 +61,7 @@ export class DiffFetcher {
 
       return result;
     } catch (e: any) {
-      logger.error("Failed to fetch incremental diff", {
+      this.log.error("Failed to fetch incremental diff", {
         baseSha,
         headSha,
         error: e.message,
@@ -71,7 +75,7 @@ export class DiffFetcher {
     baseSha: string,
     headSha: string
   ): Promise<any[]> {
-    logger.debug("Fetching target branch diff", {
+    this.log.debug("Fetching target branch diff", {
       baseSha,
       headSha,
       owner: this.issueDetails.owner,
@@ -88,7 +92,7 @@ export class DiffFetcher {
 
       const files = diff.data.files || [];
 
-      logger.info("Target branch diff fetched successfully", {
+      this.log.info("Target branch diff fetched successfully", {
         baseSha,
         headSha,
         filesCount: files.length,
@@ -97,7 +101,7 @@ export class DiffFetcher {
 
       return files;
     } catch (e: any) {
-      logger.error("Failed to fetch target branch diff", {
+      this.log.error("Failed to fetch target branch diff", {
         baseSha,
         headSha,
         error: e.message,
@@ -111,7 +115,7 @@ export class DiffFetcher {
     incrementalFiles: any[],
     targetBranchFiles: any[]
   ): boolean {
-    logger.debug("Validating diff data", {
+    this.log.debug("Validating diff data", {
       hasIncrementalFiles: !!incrementalFiles,
       hasTargetBranchFiles: !!targetBranchFiles,
       incrementalFilesCount: incrementalFiles?.length || 0,
@@ -119,14 +123,14 @@ export class DiffFetcher {
     });
 
     if (!incrementalFiles || !targetBranchFiles) {
-      logger.warn("Diff data validation failed: files data is missing", {
+      this.log.warn("Diff data validation failed: files data is missing", {
         hasIncrementalFiles: !!incrementalFiles,
         hasTargetBranchFiles: !!targetBranchFiles,
       });
       return false;
     }
 
-    logger.debug("Diff data validation passed", {
+    this.log.debug("Diff data validation passed", {
       incrementalFilesCount: incrementalFiles.length,
       targetBranchFilesCount: targetBranchFiles.length,
     });

--- a/apps/github-app/src/services/files/FileFilter.ts
+++ b/apps/github-app/src/services/files/FileFilter.ts
@@ -1,4 +1,4 @@
-import { logger } from "@/utils/logger";
+import { logger, type Logger } from "@/utils/logger";
 
 export interface FilterResult {
   selected: any[];
@@ -9,11 +9,17 @@ export interface FilterResult {
  * Filters and selects files for review
  */
 export class FileFilter {
+  private readonly log: Logger;
+
+  constructor(log?: Logger) {
+    this.log = log ?? logger;
+  }
+
   filterChangedFiles(
     targetBranchFiles: any[],
     incrementalFiles: any[]
   ): any[] {
-    logger.debug("Filtering changed files", {
+    this.log.debug("Filtering changed files", {
       targetBranchFilesCount: targetBranchFiles.length,
       incrementalFilesCount: incrementalFiles.length,
     });
@@ -25,7 +31,7 @@ export class FileFilter {
       )
     );
 
-    logger.info("Changed files filtered", {
+    this.log.info("Changed files filtered", {
       inputTargetFiles: targetBranchFiles.length,
       inputIncrementalFiles: incrementalFiles.length,
       outputChangedFiles: result.length,
@@ -36,7 +42,7 @@ export class FileFilter {
   }
 
   applyFileIgnoreRules(files: any[]): FilterResult {
-    logger.debug("Applying file ignore rules", {
+    this.log.debug("Applying file ignore rules", {
       inputFilesCount: files.length,
     });
 
@@ -51,7 +57,7 @@ export class FileFilter {
       filterSelectedFiles.push(file);
     }
 
-    logger.info("File ignore rules applied", {
+    this.log.info("File ignore rules applied", {
       inputFiles: files.length,
       selectedFiles: filterSelectedFiles.length,
       ignoredFiles: filterIgnoredFiles.length,
@@ -64,14 +70,14 @@ export class FileFilter {
   }
 
   validateFiles(files: any[], context: string): boolean {
-    logger.debug("Validating files", {
+    this.log.debug("Validating files", {
       context,
       hasFiles: !!files,
       fileCount: files?.length ?? 0,
     });
 
     if (!files || files.length === 0) {
-      logger.warn("File validation failed", {
+      this.log.warn("File validation failed", {
         context,
         fileCount: files?.length ?? 0,
         reason: !files ? 'files is null/undefined' : 'files array is empty',
@@ -79,7 +85,7 @@ export class FileFilter {
       return false;
     }
 
-    logger.debug("File validation passed", {
+    this.log.debug("File validation passed", {
       context,
       fileCount: files.length,
     });

--- a/apps/github-app/src/services/hunks/HunkProcessor.ts
+++ b/apps/github-app/src/services/hunks/HunkProcessor.ts
@@ -1,7 +1,7 @@
 import type { Context } from "probot";
 import type { IssueDetails } from "@/types/issue";
 import pLimit from "p-limit";
-import { logger } from "@/utils/logger";
+import { logger, type Logger } from "@/utils/logger";
 
 // Helper types
 export type FileWithHunks = [
@@ -26,12 +26,15 @@ interface ParsedHunk {
  */
 export class HunkProcessor {
   private readonly concurrencyLimit = pLimit(5);
+  private readonly log: Logger;
 
   constructor(
     private readonly octokit: Context["octokit"],
-    private readonly issueDetails: IssueDetails
+    private readonly issueDetails: IssueDetails,
+    log?: Logger
   ) {
-    logger.debug("HunkProcessor initialized", {
+    this.log = log ?? logger;
+    this.log.debug("HunkProcessor initialized", {
       owner: issueDetails.owner,
       repo: issueDetails.repo,
       concurrencyLimit: 5,
@@ -40,11 +43,11 @@ export class HunkProcessor {
 
   private splitPatch(patch: string | null | undefined): string[] {
     if (!patch) {
-      logger.debug("splitPatch received null/undefined patch");
+      this.log.debug("splitPatch received null/undefined patch");
       return [];
     }
 
-    logger.debug("Splitting patch", {
+    this.log.debug("Splitting patch", {
       patchLength: patch.length,
     });
 
@@ -65,7 +68,7 @@ export class HunkProcessor {
       result.push(patch.substring(last));
     }
 
-    logger.debug("Patch split complete", {
+    this.log.debug("Patch split complete", {
       splitCount: result.length,
       patchLength: patch.length,
     });
@@ -77,7 +80,7 @@ export class HunkProcessor {
     const pattern = /@@ -(\d+),(\d+) \+(\d+),(\d+) @@/;
     const match = patch.match(pattern);
     if (!match) {
-      logger.debug("Failed to match patch pattern", {
+      this.log.debug("Failed to match patch pattern", {
         patchPreview: patch.substring(0, 100),
       });
       return null;
@@ -88,7 +91,7 @@ export class HunkProcessor {
     const newBegin = parseInt(match[3]);
     const newDiff = parseInt(match[4]);
 
-    logger.debug("Parsed patch line numbers", {
+    this.log.debug("Parsed patch line numbers", {
       oldRange: `${oldBegin}-${oldBegin + oldDiff - 1}`,
       newRange: `${newBegin}-${newBegin + newDiff - 1}`,
     });
@@ -159,7 +162,7 @@ export class HunkProcessor {
     files: any[],
     baseSha: string
   ): Promise<FileWithHunks[]> {
-    logger.info("Starting hunk processing", {
+    this.log.info("Starting hunk processing", {
       filesCount: files.length,
       baseSha,
       concurrencyLimit: 5,
@@ -173,7 +176,7 @@ export class HunkProcessor {
     const filteredFiles = await Promise.all(
       files.map((file) =>
         this.concurrencyLimit(async () => {
-          logger.debug("Processing file into hunks", {
+          this.log.debug("Processing file into hunks", {
             filename: file.filename,
             status: file.status,
             additions: file.additions,
@@ -202,7 +205,7 @@ export class HunkProcessor {
                     "base64"
                   ).toString();
 
-                  logger.debug("File content retrieved", {
+                  this.log.debug("File content retrieved", {
                     filename: file.filename,
                     contentLength: fileContent.length,
                     encoding: contents.data.encoding,
@@ -212,7 +215,7 @@ export class HunkProcessor {
             }
           } catch (e: any) {
             newFileCount++;
-            logger.debug("Failed to get file contents", {
+            this.log.debug("Failed to get file contents", {
               filename: file.filename,
               error: e.message,
               status: e.status,
@@ -228,7 +231,7 @@ export class HunkProcessor {
           const patches: Array<[number, number, string]> = [];
           const splitPatches = this.splitPatch(file.patch);
 
-          logger.debug("Split patches for file", {
+          this.log.debug("Split patches for file", {
             filename: file.filename,
             patchCount: splitPatches.length,
           });
@@ -262,7 +265,7 @@ ${hunks.oldHunk}
 
           if (patches.length > 0) {
             successCount++;
-            logger.debug("File processed successfully with hunks", {
+            this.log.debug("File processed successfully with hunks", {
               filename: file.filename,
               patchesCount: patches.length,
               contentLength: fileContent.length,
@@ -275,7 +278,7 @@ ${hunks.oldHunk}
             ];
           } else {
             failedCount++;
-            logger.warn("No patches generated for file", {
+            this.log.warn("No patches generated for file", {
               filename: file.filename,
               hasPatch: !!file.patch,
               patchLength: file.patch?.length || 0,
@@ -288,7 +291,7 @@ ${hunks.oldHunk}
 
     const duration = Date.now() - startTime;
 
-    logger.info("Hunk processing completed", {
+    this.log.info("Hunk processing completed", {
       totalFiles: files.length,
       successCount,
       failedCount,

--- a/apps/github-app/src/services/preprocessing/PRPreprocessor.ts
+++ b/apps/github-app/src/services/preprocessing/PRPreprocessor.ts
@@ -3,7 +3,7 @@ import { DiffFetcher } from "@/services/diffs/DiffFetcher";
 import { FileFilter } from "@/services/files/FileFilter";
 import { HunkProcessor } from "@/services/hunks/HunkProcessor";
 import type { IssueDetails } from "@/types/issue";
-import { logger } from "@/utils/logger";
+import { logger, type Logger } from "@/utils/logger";
 
 export type FileWithHunks = [string, string, string, Array<[number, number, string]>];
 
@@ -27,19 +27,22 @@ export class PRPreprocessor {
   private readonly diffFetcher: DiffFetcher;
   private readonly fileFilter: FileFilter;
   private readonly hunkProcessor: HunkProcessor;
+  private readonly log: Logger;
 
   constructor(
     octokit: Context["octokit"],
-    issueDetails: IssueDetails
+    issueDetails: IssueDetails,
+    log?: Logger
   ) {
-    logger.debug("PRPreprocessor initialized", {
+    this.log = log ?? logger;
+    this.log.debug("PRPreprocessor initialized", {
       owner: issueDetails.owner,
       repo: issueDetails.repo,
     });
-    this.diffFetcher = new DiffFetcher(octokit, issueDetails);
-    this.fileFilter = new FileFilter();
-    this.hunkProcessor = new HunkProcessor(octokit, issueDetails);
-    logger.debug("PRPreprocessor services created");
+    this.diffFetcher = new DiffFetcher(octokit, issueDetails, this.log);
+    this.fileFilter = new FileFilter(this.log);
+    this.hunkProcessor = new HunkProcessor(octokit, issueDetails, this.log);
+    this.log.debug("PRPreprocessor services created");
   }
 
   /**
@@ -50,7 +53,7 @@ export class PRPreprocessor {
     headSha: string,
     reviewStartSha?: string
   ): Promise<PreprocessResult> {
-    logger.info("Starting PR preprocessing", {
+    this.log.info("Starting PR preprocessing", {
       baseSha,
       headSha,
       reviewStartSha,
@@ -66,13 +69,13 @@ export class PRPreprocessor {
 
     // Use reviewStartSha for incremental diff if provided, otherwise use baseSha
     const incrementalBase = reviewStartSha ?? baseSha;
-    logger.debug("Determined incremental base", {
+    this.log.debug("Determined incremental base", {
       incrementalBase,
       usingReviewStart: incrementalBase === reviewStartSha,
     });
 
     // Step 1: Fetch diffs
-    logger.debug("Fetching diffs", {
+    this.log.debug("Fetching diffs", {
       incrementalBase,
       headSha,
       baseSha,
@@ -88,59 +91,59 @@ export class PRPreprocessor {
       headSha
     );
 
-    logger.info("Diffs fetched successfully", {
+    this.log.info("Diffs fetched successfully", {
       incrementalFilesCount: incrementalDiff.files.length,
       targetBranchFilesCount: targetBranchFiles.length,
       commitsCount: incrementalDiff.commits.length,
     });
 
     // Step 2: Validate diff data
-    logger.debug("Validating diff data");
+    this.log.debug("Validating diff data");
     if (!this.diffFetcher.validateDiffData(incrementalDiff.files, targetBranchFiles)) {
-      logger.warn("Invalid diff data during preprocessing", { baseSha, headSha });
+      this.log.warn("Invalid diff data during preprocessing", { baseSha, headSha });
       return emptyResult;
     }
-    logger.debug("Diff data validated successfully");
+    this.log.debug("Diff data validated successfully");
 
     // Step 3: Filter files
-    logger.debug("Filtering changed files");
+    this.log.debug("Filtering changed files");
     const changedFiles = this.fileFilter.filterChangedFiles(
       targetBranchFiles,
       incrementalDiff.files
     );
 
-    logger.info("Changed files filtered", {
+    this.log.info("Changed files filtered", {
       changedFilesCount: changedFiles.length,
       targetBranchFilesCount: targetBranchFiles.length,
       incrementalFilesCount: incrementalDiff.files.length,
     });
 
     if (!this.fileFilter.validateFiles(changedFiles, "files is null")) {
-      logger.warn("No changed files after filtering");
+      this.log.warn("No changed files after filtering");
       return emptyResult;
     }
 
-    logger.debug("Applying file ignore rules");
+    this.log.debug("Applying file ignore rules");
     const filterResult = this.fileFilter.applyFileIgnoreRules(changedFiles);
 
-    logger.info("File ignore rules applied", {
+    this.log.info("File ignore rules applied", {
       selectedCount: filterResult.selected.length,
       ignoredCount: filterResult.ignored.length,
       totalFiles: changedFiles.length,
     });
 
     if (!this.fileFilter.validateFiles(filterResult.selected, "filterSelectedFiles is null")) {
-      logger.warn("No files selected after applying ignore rules");
+      this.log.warn("No files selected after applying ignore rules");
       return emptyResult;
     }
 
     if (filterResult.selected.length === 0) {
-      logger.info("No files to process after filtering", { baseSha, headSha });
+      this.log.info("No files to process after filtering", { baseSha, headSha });
       return { ...emptyResult, filterResult, success: true };
     }
 
     // Step 4: Process files into hunks
-    logger.debug("Processing files into hunks", {
+    this.log.debug("Processing files into hunks", {
       filesCount: filterResult.selected.length,
       baseSha,
     });
@@ -155,7 +158,7 @@ export class PRPreprocessor {
       (file): file is FileWithHunks => file !== null
     );
 
-    logger.info("PR preprocessing completed successfully", {
+    this.log.info("PR preprocessing completed successfully", {
       filesWithHunksCount: filesAndChanges.length,
       nullFilesCount: filteredFiles.length - filesAndChanges.length,
       totalCommits: incrementalDiff.commits.length,


### PR DESCRIPTION
…vices

Services like CommentManager, Prompts, CommitAnalyzer, DiffFetcher, FileFilter, HunkProcessor, and PRPreprocessor were using the global root logger directly, bypassing the child logger created with repo/prNumber context in PRWorkflowOrchestrator. This caused those log lines to appear in PostHog without the identifying prefix.

Each affected class now accepts an optional log?: Logger constructor parameter (defaulting to root logger), and all instantiation sites pass the contextual prLogger/this.log down so every log line carries the full repo | installationId | prNumber prefix.

## Summary by Sourcery

Enhancements:
- Add optional logger dependency to PR workflow services and default to the root logger when none is provided.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced internal logging infrastructure to provide improved diagnostics and context-aware traceability throughout PR review, summary generation, and architecture analysis operations, improving system observability and troubleshooting capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->